### PR TITLE
feat: add envtime variable as required

### DIFF
--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -9,6 +9,9 @@ on:
       WF_ENV_TYPE:
         type: string
         required: true
+      WF_ENV_TYPE_DEPLOY:
+        type: string
+        required: true
       WF_NODE_VERSION:
         type: string
         required: true
@@ -35,7 +38,7 @@ jobs:
   setup:
     name: preparing
     runs-on: ubuntu-latest
-    environment: ${{inputs.WF_ENV_TYPE}}
+    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
     continue-on-error: false
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -35,7 +35,7 @@ jobs:
   setup:
     name: preparing
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{inputs.WF_ENV_TYPE}}
     continue-on-error: false
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -6,6 +6,9 @@ on:
       WF_NODE_VERSION:
         type: string
         required: true
+      WF_ENV_TYPE:
+        type: string
+        required: true
       WF_PUBLISH_CODE_COVERAGE:
         type: string
         default: false
@@ -32,6 +35,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   setup:
+    environment: ${{inputs.WF_ENV_TYPE}}
     name: preparing
     runs-on: ubuntu-latest
     continue-on-error: false

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -6,7 +6,7 @@ on:
       WF_NODE_VERSION:
         type: string
         required: true
-      WF_ENV_TYPE:
+      WF_ENV_TYPE_DEPLOY:
         type: string
         required: true
       WF_PUBLISH_CODE_COVERAGE:
@@ -35,7 +35,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   setup:
-    environment: ${{inputs.WF_ENV_TYPE}}
+    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
     name: preparing
     runs-on: ubuntu-latest
     continue-on-error: false

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -3,6 +3,9 @@ name: CI-K8-BASE
 on:
   workflow_call:
     inputs:
+      WF_ENV_TYPE_DEPLOY:
+        type: string
+        required: true
       WF_ENV_TYPE:
         type: string
         required: true
@@ -72,7 +75,7 @@ jobs:
   setup:
     name: preparing
     runs-on: ubuntu-latest
-    environment: ${{inputs.WF_ENV_TYPE}}
+    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
     continue-on-error: false
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -72,7 +72,7 @@ jobs:
   setup:
     name: preparing
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{inputs.WF_ENV_TYPE}}
     continue-on-error: false
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci_k8_undeploy_base.yml
+++ b/.github/workflows/ci_k8_undeploy_base.yml
@@ -26,7 +26,7 @@ jobs:
   setup:
     name: preparing
     runs-on: ubuntu-latest
-    environment: production
+    environment: ${{inputs.WF_ENV_TYPE}}
     continue-on-error: false
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/.github/workflows/ci_k8_undeploy_base.yml
+++ b/.github/workflows/ci_k8_undeploy_base.yml
@@ -6,6 +6,9 @@ on:
       WF_ENV_TYPE:
         type: string
         required: true
+      WF_ENV_TYPE_DEPLOY:
+        type: string
+        required: true
         
     secrets:
       WF_KUBE_TYPE:
@@ -26,7 +29,7 @@ jobs:
   setup:
     name: preparing
     runs-on: ubuntu-latest
-    environment: ${{inputs.WF_ENV_TYPE}}
+    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
     continue-on-error: false
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:


### PR DESCRIPTION
# Context

BREAKING CHANGE: This commit breaks the previous versions because adds the WF_ENV_TYPE_DEPLOY as required in all workflows files:  `base_node_build.yml`, `base_build_push_ecr.yml`, `ci_k8_base.yml`, `ci_k8_undeploy.yml`

```yml
WF_ENV_TYPE_DEPLOY:
        type: string
        required: true
```

This commit changes the CI/CD files to use ${{inputs.WF_ENV_TYPE_DEPLOY}} as a job environment.

Example:
```yml
jobs:
  setup:
    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
```
## How to use this CI?

- [ ]  Edit the files on each project .github/workflow/push_stage.yml and set the `WF_ENV_TYPE_DEPLOY: staging`
- [ ]  Edit the files on each project .github/workflow/push_main.yml and set the `WF_ENV_TYPE_DEPLOY: production`
- [ ]  Edit the files on each project .github/workflow/pr_open.yml and set the `WF_ENV_TYPE_DEPLOY: dev`
- [ ]  Edit the files on each project .github/workflow/pr_close.yml and set the `WF_ENV_TYPE_DEPLOY: dev`


Example: 
```yml
jobs:
  base-setup:
    uses: QueroDelivery/ci/.github/workflows/base_node_build.yml@main
    with:
      WF_ENV_TYPE_DEPLOY: staging
```


## Files modified
 On branch feat/add-envtype
 Changes to be committed:
	modified:   .github/workflows/base_build_push_ecr.yml
	modified:   .github/workflows/base_node_build.yml
	modified:   .github/workflows/ci_k8_base.yml
	modified:   .github/workflows/ci_k8_undeploy_base.yml

footer: this commit is related to improvement on CI/CD asked by Junior