### PR TITLE
Add dotenv Creation Before Build

### DIFF
--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -135,6 +135,7 @@ jobs:
           VERSION_TAG: ${{ github.sha }}
           SERVICE_NAME: ${{ inputs.WF_SERVICE_NAME }}
         run: |
+          ls -la
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -138,8 +138,6 @@ jobs:
           VERSION_TAG: ${{ github.sha }}
           SERVICE_NAME: ${{ inputs.WF_SERVICE_NAME }}
         run: |
-          ls -la
-          cat .env
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -118,7 +118,7 @@ jobs:
         if: ${{ inputs.WF_CREATE_DOTENV_BEFORE_BUILD }}
         id: 'dotenv-from-parameter-store'
         with:
-          output: .env
+          output: ./.env
           ssm-path: '/${{ inputs.WF_ENV_TYPE }}/${{ secrets.WF_SERVICE_NAME }}'
           format: dotenv
         env:
@@ -136,6 +136,7 @@ jobs:
           SERVICE_NAME: ${{ inputs.WF_SERVICE_NAME }}
         run: |
           ls -la
+          cat .env
           # Build a docker container and
           # push it to ECR so that it can
           # be deployed to ECS.

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -12,6 +12,10 @@ on:
       WF_NODE_VERSION:
         type: string
         required: true
+      WF_CREATE_DOTENV_BEFORE_BUILD:
+        type: boolean
+        default: false
+        required: false
     secrets:
       WF_NPM_TOKEN:
         required: true
@@ -108,6 +112,19 @@ jobs:
           else
             echo "Branch does not needs to be updated. Semantic-release had not run yet"
           fi
+      
+      - name: Creating dotenv from aws parameter store
+        uses: almerindo/action-env-from-aws-ssm@main
+        if: ${{ inputs.WF_CREATE_DOTENV_BEFORE_BUILD }}
+        id: 'dotenv-from-parameter-store'
+        with:
+          output: .env
+          ssm-path: '/${{ inputs.WF_ENV_TYPE }}/${{ secrets.WF_SERVICE_NAME }}'
+          format: dotenv
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.WF_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.WF_AWS_REGION }}
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
This pull request introduces a new feature that enables the creation of a dotenv file before the build process. The primary goal is to facilitate the usage of environment variables by frontend applications like Vite, allowing for easy configuration and access to important settings.