### PR TITLE
Build once deploy many

### DIFF
--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -62,17 +62,24 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: '${{ inputs.WF_SERVICE_NAME }}'
-          IMAGE_TAG: latest
           VERSION_TAG: ${{ github.sha }}
         run: |
           gunzip -c image.tar.gz | docker load
           IMAGE_ID=$(docker images -q)
+          PR_NUMBER=${{ github.event.pull_request.number }}
           
-          docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          # Tag with PR number (if available)
+          if [ -n "$PR_NUMBER" ]; then
+            docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:pr-$PR_NUMBER
+            docker push $ECR_REGISTRY/$ECR_REPOSITORY:pr-$PR_NUMBER
+          fi
+
           docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
 
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
+          docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$WF_ENV_TYPE_DEPLOY
+
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$WF_ENV_TYPE_DEPLOY
 
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -27,6 +27,9 @@ on:
       servicename:
         description: "The service name"
         value: ${{ jobs.setup.outputs.servicename }}
+      digest:
+        description: "The image digest"
+        value: ${{ jobs.setup.outputs.digest }}
 
 jobs:
   setup:
@@ -35,6 +38,7 @@ jobs:
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}
+      digest: ${{ steps.load-image.outputs.servicename }}
 
     steps:
       - uses: actions/checkout@v4
@@ -56,16 +60,17 @@ jobs:
           name: built-image
 
       - name: Load image and push to ECR
+        id: load-image
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: '${{ inputs.WF_SERVICE_NAME }}'
-          ENV_TYPE_DEPLOY: '${{ inputs.WF_ENV_TYPE_DEPLOY }}'
+          ECR_REPOSITORY: "${{ inputs.WF_SERVICE_NAME }}"
+          ENV_TYPE_DEPLOY: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
           VERSION_TAG: ${{ github.sha }}
         run: |
           gunzip -c image.tar.gz | docker load
           IMAGE_ID=$(docker images -q)
           PR_NUMBER=${{ github.event.pull_request.number }}
-          
+
           # Tag with PR number (if available)
           if [ -n "$PR_NUMBER" ]; then
             docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:pr-$PR_NUMBER
@@ -79,6 +84,9 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV_TYPE_DEPLOY
 
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG" >> $GITHUB_OUTPUT
+
+          DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE_ID | cut -d'@' -f2)
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Output service name
         id: service-name

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -38,7 +38,7 @@ jobs:
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}
-      digest: ${{ steps.load-image.outputs.servicename }}
+      digest: ${{ steps.load-image.outputs.digest }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -62,6 +62,7 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: '${{ inputs.WF_SERVICE_NAME }}'
+          ENV_TYPE_DEPLOY: '${{ inputs.WF_ENV_TYPE_DEPLOY }}'
           VERSION_TAG: ${{ github.sha }}
         run: |
           gunzip -c image.tar.gz | docker load
@@ -75,11 +76,10 @@ jobs:
           fi
 
           docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
-
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
-          docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$WF_ENV_TYPE_DEPLOY
 
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$WF_ENV_TYPE_DEPLOY
+          docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$ENV_TYPE_DEPLOY
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV_TYPE_DEPLOY
 
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Load image and push to ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: '${{ inputs.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo'
+          ECR_REPOSITORY: '${{ inputs.WF_SERVICE_NAME }}'
           IMAGE_TAG: latest
           VERSION_TAG: ${{ github.sha }}
         run: |

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -6,9 +6,6 @@ on:
       WF_SERVICE_NAME:
         type: string
         required: true
-      WF_ENV_TYPE:
-        type: string
-        required: true
       WF_ENV_TYPE_DEPLOY:
         type: string
         required: true

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -1,5 +1,5 @@
-# This is a basic workflow to help you get started with Actions
 name: CI-ECR-BASE
+
 on:
   workflow_call:
     inputs:
@@ -15,19 +15,8 @@ on:
       WF_NODE_VERSION:
         type: string
         required: true
-      WF_CREATE_DOTENV_BEFORE_BUILD:
-        type: boolean
-        default: false
-        required: false
-      WF_FONT_AWESOME_TOKEN:
-        type: string
-        required: false
 
     secrets:
-      WF_NPM_TOKEN:
-        required: true
-      WF_NPM_USER:
-        required: true
       WF_GITHUB_TOKEN:
         required: true
       WF_AWS_ACCESS_KEY_ID:
@@ -36,135 +25,57 @@ on:
         required: true
       WF_AWS_REGION:
         required: true
-      WF_FONT_AWESOME_TOKEN:
-        required: false
+
     outputs:
       servicename:
         description: "The service name"
         value: ${{ jobs.setup.outputs.servicename }}
-        
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+
 jobs:
   setup:
-    name: preparing
-    env:
-      FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
+    name: push-to-ecr
     runs-on: ubuntu-latest
-    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
-    continue-on-error: false
+    environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}
-      
-    # Steps represent a sequence of tasks that will be executed as part of the job
+
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout tools repo
-        uses: actions/checkout@v4
-        with:
-          ref: add-step-create-repository
-          token: ${{ secrets.WF_GITHUB_TOKEN }} 
-          repository: QueroDelivery/ci
-          path: setup/
-          persist-credentials: false
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.WF_NODE_VERSION }}
-          cache: 'yarn'
-          registry-url: ${{secrets.WF_REGISTRY}}
-      
-      - name: Configure AWS credentials without role
+
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.WF_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.WF_AWS_REGION }}
 
-      - name: Create ECR repo if is initial commit
-        env:
-          REPO_PROD_NAME: ${{inputs.WF_SERVICE_NAME}}_prod_repo
-          REPO_STAGE_NAME: ${{inputs.WF_SERVICE_NAME}}_stage_repo
-        run: |
-          if [[ "${{ github.event.head_commit.message }}" == "initial commit" ]]; then
-            cd setup
-
-            echo "This step will create repositories on ECR to push docker image to staging and production environments"
-
-            echo ${REPO_PROD_NAME}
-
-            aws ecr describe-repositories --repository-names ${REPO_PROD_NAME} --no-cli-pager || aws ecr  create-repository --repository-name ${REPO_PROD_NAME} --no-cli-pager
-              
-            echo ${REPO_STAGE_NAME}
-            
-            aws ecr  describe-repositories --repository-names ${REPO_STAGE_NAME} --no-cli-pager || aws ecr  create-repository --repository-name ${REPO_STAGE_NAME} --no-cli-pager
-
-            aws ecr  get-lifecycle-policy --repository-name ${REPO_PROD_NAME} --no-cli-pager || aws ecr  put-lifecycle-policy --repository-name ${REPO_PROD_NAME} --lifecycle-policy-text file://ecr_policy.json --no-cli-pager
-            aws ecr  get-lifecycle-policy --repository-name ${REPO_STAGE_NAME} --no-cli-pager || aws ecr  put-lifecycle-policy --repository-name ${REPO_STAGE_NAME} --lifecycle-policy-text file://ecr_policy.json --no-cli-pager
-         
-          else
-            echo "Doesn't running create ECR repositories"
-          
-          fi
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
-      
-      - name: Update with new version
-        run: |
-          echo "getting branch"
-          echo ${GITHUB_REF#refs/heads/}
-          echo  "Updating the code with released version"
-        
-          BRANCH=${GITHUB_REF#refs/heads/}
-          
-          if [[ "$BRANCH" = "stage" || "$BRANCH" = "main" ]]; then
-            git pull origin $BRANCH
-            echo "Branch updated with the last version"
-          else
-            echo "Branch does not needs to be updated. Semantic-release had not run yet"
-          fi
-      
-      - name: Creating dotenv from aws parameter store
-        uses: almerindo/action-env-from-aws-ssm@main
-        if: ${{ inputs.WF_CREATE_DOTENV_BEFORE_BUILD }}
-        id: 'dotenv-from-parameter-store'
-        with:
-          output: ./.env
-          ssm-path: '/${{ inputs.WF_ENV_TYPE }}/${{ secrets.WF_SERVICE_NAME }}'
-          format: dotenv
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.WF_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.WF_AWS_REGION }}
 
-      - name: Build, tag, and push image to Amazon ECR
-        id: build-image
+      - name: Download built image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: built-image
+
+      - name: Load image and push to ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: '${{inputs.WF_SERVICE_NAME}}_${{inputs.WF_ENV_TYPE}}_repo'
+          ECR_REPOSITORY: '${{ inputs.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo'
           IMAGE_TAG: latest
           VERSION_TAG: ${{ github.sha }}
-          SERVICE_NAME: ${{ inputs.WF_SERVICE_NAME }}
         run: |
-          # Build a docker container and
-          # push it to ECR so that it can
-          # be deployed to ECS.
-          echo "registry=http://registry.npmjs.org/" > .npmrc && echo "${{ secrets.WF_NPM_USER }}:registry=https://npm.pkg.github.com" >> .npmrc && echo "//npm.pkg.github.com/:_authToken=${{ secrets.WF_NPM_TOKEN }}" >> .npmrc && echo "@fortawesome:registry=https://npm.fontawesome.com/" >> .npmrc && echo "//npm.fontawesome.com/:_authToken=${{ secrets.WF_FONT_AWESOME_TOKEN }}" >> .npmrc
-
-          docker build --build-arg SERVICE_NAME=$SERVICE_NAME -t $ECR_REPOSITORY:$IMAGE_TAG -t $ECR_REPOSITORY:$VERSION_TAG .
-          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-          docker tag $ECR_REPOSITORY:$VERSION_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
+          gunzip -c image.tar.gz | docker load
+          IMAGE_ID=$(docker images -q)
           
+          docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
+
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
+
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG" >> $GITHUB_OUTPUT
 
-          echo "COMMIT-HASH --> $VERSION_TAG"
-          hash=$(git rev-parse HEAD)
-          echo $hash
-           
-      - name: Setting service name outputs
+      - name: Output service name
         id: service-name
-        run: |
-          export SERVICE_NAME=${{inputs.WF_SERVICE_NAME}}
-          echo "servicename=$SERVICE_NAME" >> $GITHUB_OUTPUT
-          
+        run: echo "servicename=${{ inputs.WF_SERVICE_NAME }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -80,9 +80,12 @@ jobs:
           docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG
 
-          docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$ENV_TYPE_DEPLOY
-          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV_TYPE_DEPLOY
-
+          if [ "$ENV_TYPE_DEPLOY" != "dev" ]; then
+            docker tag $IMAGE_ID $ECR_REGISTRY/$ECR_REPOSITORY:$ENV_TYPE_DEPLOY
+            docker push $ECR_REGISTRY/$ECR_REPOSITORY:$ENV_TYPE_DEPLOY
+          else
+            echo "⚠️ Skipping tag with ENV_TYPE_DEPLOY=dev"
+          fi
           echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$VERSION_TAG" >> $GITHUB_OUTPUT
 
           DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' $IMAGE_ID | cut -d'@' -f2)

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -73,6 +73,11 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
 
+      - name: Set up .npmrc
+        run: |
+          echo "@querodelivery:registry=https://npm.pkg.github.com" > ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.WF_NPM_TOKEN }}" >> ~/.npmrc
+
       - name: install packages using yarn.lock
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -1,5 +1,5 @@
-# This is a basic workflow to help you get started with Actions
 name: CI-BASE
+
 on:
   workflow_call:
     inputs:
@@ -31,15 +31,15 @@ on:
         required: true
       WF_FONT_AWESOME_TOKEN:
         required: false
+
     outputs:
       servicename:
         description: "The service name"
         value: ${{ jobs.setup.outputs.output1 }}
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   setup:
-    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
+    environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
@@ -48,9 +48,7 @@ jobs:
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -60,7 +58,7 @@ jobs:
         with:
           node-version: ${{ inputs.WF_NODE_VERSION }}
           cache: "yarn"
-          registry-url: ${{secrets.WF_REGISTRY}}
+          registry-url: ${{ secrets.WF_REGISTRY }}
 
       - name: Cache NPM dependencies
         id: node-modules-cache
@@ -74,34 +72,33 @@ jobs:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
       - name: install packages using yarn.lock
         if: steps.node-modules-cache.outputs.cache-hit != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.WF_NPM_TOKEN }}
-        run: |
-          yarn --frozen-lockfile
+        run: yarn --frozen-lockfile
 
       - name: linting
-        run: |
-          yarn lint
+        run: yarn lint
 
       - name: testing
         env:
-          RUN_PUBLISH_COVERAGE: ${{inputs.WF_PUBLISH_CODE_COVERAGE}}
-          BACKSTAGE_URL: ${{inputs.WF_BACKSTAGE_URL}}
+          RUN_PUBLISH_COVERAGE: ${{ inputs.WF_PUBLISH_CODE_COVERAGE }}
+          BACKSTAGE_URL: ${{ inputs.WF_BACKSTAGE_URL }}
         run: |
           yarn test:ci
-          COMPONENT_NAME=`node -p -e "require('./package.json').name"`
+          COMPONENT_NAME=$(node -p -e "require('./package.json').name")
           FILE=coverage/int/cobertura-coverage.xml
           if $RUN_PUBLISH_COVERAGE; then
             if [ -f "$FILE" ]; then
               curl --request POST \
-              --url ''$BACKSTAGE_URL'/api/code-coverage/report?entity=component%3Adefault%2F'$COMPONENT_NAME'&coverageType=cobertura' \
-              --header 'Content-Type: text/xml' \
-              --data @$FILE  
+                --url "$BACKSTAGE_URL/api/code-coverage/report?entity=component%3Adefault%2F$COMPONENT_NAME&coverageType=cobertura" \
+                --header 'Content-Type: text/xml' \
+                --data @$FILE
               echo "Sending coverage report to quero developer portal"
             else
-               echo "::warning:: $FILE does not exist, code coverage not sended to quero developer portal"
+              echo "::warning:: $FILE does not exist, code coverage not sent"
             fi
           fi
 
@@ -109,11 +106,24 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.WF_NPM_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
-        run: |
-          yarn release
+        run: yarn release
 
       - name: Getting SERVICE_NAME
         id: serviceName
         run: |
-          export SERVICE_NAME=`node -p -e "require('./package.json').name"`
+          SERVICE_NAME=$(node -p -e "require('./package.json').name")
           echo "servicename=$SERVICE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Build Docker image
+        run: |
+          docker build -t ${{ steps.serviceName.outputs.servicename }}:ci-build .
+
+      - name: Save Docker image
+        run: |
+          docker save ${{ steps.serviceName.outputs.servicename }}:ci-build | gzip > image.tar.gz
+
+      - name: Upload Docker image as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: built-image
+          path: image.tar.gz

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -75,8 +75,8 @@ jobs:
 
       - name: Set up .npmrc
         run: |
-          echo "@querodelivery:registry=https://npm.pkg.github.com" > ~/.npmrc
-          echo "//npm.pkg.github.com/:_authToken=${{ secrets.WF_NPM_TOKEN }}" >> ~/.npmrc
+          echo "@querodelivery:registry=https://npm.pkg.github.com" > .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.WF_NPM_TOKEN }}" >> .npmrc
 
       - name: install packages using yarn.lock
         if: steps.node-modules-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -197,30 +197,53 @@ jobs:
           gh pr comment ${{ github.event.pull_request.number }} --body "✅ Deployed image: \`${{ steps.login-ecr.outputs.registry }}/${ECR_REPOSITORY}:${{ inputs.WF_IMAGE_TAG }}\`"
           gh pr comment ${{ github.event.pull_request.number }} --body "Segura o link dessa app review aí ó o/
             -   URL: https://${{ secrets.WF_KUBE_NAME }}${{ secrets.WF_KUBE_DOMAIN }}"
+
       - name: upsert .deploys/service.json
         env:
-          IMAGE_DIGEST: ${{inputs.WF_DIGEST_IMAGE}}
+          IMAGE_DIGEST: ${{ inputs.WF_DIGEST_IMAGE }}
           FILE: "service.json"
           ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
           GITHUB_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
           IMAGE_TAG: ${{ inputs.WF_IMAGE_TAG }}
           VERSION_TAG: "${{ github.sha }}"
+          BRANCH: deploy-state
 
         run: |
-          mkdir -p .deploys && cd .deploys
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          # Fetch and create worktree
           git fetch origin $BRANCH:$BRANCH || true
           git worktree add ../deploy-worktree $BRANCH
 
-          cp ../deploy-worktree/$FILE $FILE || echo "{}" > $FILE
+          # Ensure deploys dir
+          mkdir -p .deploys
 
+          # If exists in branch, copy it; else init
+          if [ -f ../deploy-worktree/.deploys/$FILE ]; then
+            cp ../deploy-worktree/.deploys/$FILE .deploys/$FILE
+          else
+            echo "{}" > .deploys/$FILE
+          fi
 
-          # Write digest under environment key
+          # Merge or add deploy info
           jq --arg env "$ENV" \
-            --arg digest "$IMAGE_DIGEST" \
-            --arg version_tag "$VERSION_TAG" \
-            --arg image_tag "$IMAGE_TAG" \
-            '. + {($env): {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}}' \
-            "$FILE" > tmp.json && mv tmp.json "$FILE"
+             --arg digest "$IMAGE_DIGEST" \
+             --arg version_tag "$VERSION_TAG" \
+             --arg image_tag "$IMAGE_TAG" \
+             '. + {($env): {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}}' \
+             .deploys/$FILE > .deploys/tmp.json && mv .deploys/tmp.json .deploys/$FILE
+
+          cat .deploys/$FILE
+
+          # Move file back into worktree
+          cp .deploys/$FILE ../deploy-worktree/.deploys/$FILE
+
+          cd ../deploy-worktree
+          git add .deploys/$FILE
+          git commit -m "chore(ci): upsert $ENV deploy state [skip ci]" || echo "⚠️ Nothing to commit"
+          git push origin $BRANCH
+
 
           cat "$FILE"
 
@@ -253,7 +276,6 @@ jobs:
           git add "$FILE"
           git commit -m "chore(ci): promote $ENV from dev to $ENV [skip ci]" || echo "⚠️ Nothing to commit"
           git push origin $BRANCH
-
 
       - name: Open PR to main if needed
         if: ${{ inputs.WF_CREATE_PR_IN_MAIN }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -233,11 +233,11 @@ jobs:
           BRANCH: "deploy-state"
           ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
         run: |
-          it fetch origin $BRANCH:$BRANCH || git worktree add ../deploy-worktree $BRANCH
+          fetch origin $BRANCH:$BRANCH || git worktree add ../deploy-worktree $BRANCH
           cp "$FILE" ../deploy-worktree/$FILE
 
           cd ../deploy-worktree
-          
+
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -200,6 +200,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
           IMAGE_TAG: ${{ inputs.WF_IMAGE_TAG }}
           VERSION_TAG: "${{ github.sha }}"
+          BRANCH: "deploy-state"
+
 
         run: |
           mkdir -p .deploys && cd .deploys
@@ -223,9 +225,14 @@ jobs:
           # Commit changes
           git config user.name "github-actions"
           git config user.email "actions@github.com"
+
+          git fetch origin $BRANCH:$BRANCH || git checkout --orphan $BRANCH
+          git switch $BRANCH
+
+
           git add "$FILE"
-          git commit -m "chore(ci): update digest for $ENV"
-          git push origin HEAD
+          git commit -m "chore(ci): update digest for $ENV [skip ci]"
+          git push origin $BRANCH
 
       - name: Open PR to main if needed
         if: ${{ inputs.WF_CREATE_PR_IN_MAIN }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -195,13 +195,11 @@ jobs:
       - name: upsert .deploys/service.json
         env:
           IMAGE_DIGEST: ${{inputs.WF_DIGEST_IMAGE}}
-          FILE: 'service.json'
+          FILE: "service.json"
           ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
           GITHUB_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
           IMAGE_TAG: ${{ inputs.WF_IMAGE_TAG }}
           VERSION_TAG: "${{ github.sha }}"
-          BRANCH: "deploy-state"
-
 
         run: |
           mkdir -p .deploys && cd .deploys
@@ -221,14 +219,25 @@ jobs:
             "$FILE" > tmp.json && mv tmp.json "$FILE"
 
           cat "$FILE"
-          
-          # Commit changes
+
+      - name: Handle dev layer vs tracked environments
+        if: ${{ inputs.WF_ENV_TYPE_DEPLOY == 'dev' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-deploy-state
+          path: .deploys/service.json
+
+      - name: Commit & Push deploy state (stg/prod)
+        if: ${{ inputs.WF_ENV_TYPE_DEPLOY != 'dev' }}
+        env:
+          BRANCH: "deploy-state"
+          ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
+        run: |
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 
           git fetch origin $BRANCH:$BRANCH || git checkout --orphan $BRANCH
           git switch $BRANCH
-
 
           git add "$FILE"
           git commit -m "chore(ci): update digest for $ENV [skip ci]"

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -239,11 +239,6 @@ jobs:
           # Move file back into worktree
           cp .deploys/$FILE ../deploy-worktree/.deploys/$FILE
 
-          cd ../deploy-worktree
-          git add .deploys/$FILE
-          git commit -m "chore(ci): upsert $ENV deploy state [skip ci]" || echo "⚠️ Nothing to commit"
-          git push origin $BRANCH
-
 
       - name: Handle dev layer vs tracked environments
         if: ${{ inputs.WF_ENV_TYPE_DEPLOY == 'dev' }}
@@ -259,21 +254,35 @@ jobs:
           ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
           FILE: ".deploys/service.json"
         run: |
+          # Setup Git identity
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 
-          # Cria diretório isolado para o worktree
-          git fetch origin $BRANCH:$BRANCH || true
+          # Remove worktree if already exists (idempotency)
+          if [ -d "../deploy-worktree" ]; then
+            echo "🧹 Cleaning up existing worktree"
+            git worktree remove --force ../deploy-worktree || true
+          fi
+
+          # Fetch remote branch into local if needed
+          if ! git show-ref --verify --quiet refs/remotes/origin/$BRANCH; then
+            git fetch origin $BRANCH:$BRANCH || git checkout --orphan $BRANCH
+          else
+            git fetch origin $BRANCH
+          fi
+
+          # Add isolated worktree for that branch
           git worktree add ../deploy-worktree $BRANCH
 
-          # Copia o service.json gerado
+          # Copy generated .deploys/service.json into worktree
           cp "$FILE" ../deploy-worktree/$FILE
 
+          # Commit and push if there are changes
           cd ../deploy-worktree
-
           git add "$FILE"
           git commit -m "chore(ci): promote $ENV from dev to $ENV [skip ci]" || echo "⚠️ Nothing to commit"
           git push origin $BRANCH
+
 
       - name: Open PR to main if needed
         if: ${{ inputs.WF_CREATE_PR_IN_MAIN }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -208,12 +208,11 @@ jobs:
 
         run: |
           mkdir -p .deploys && cd .deploys
-          # Create or update JSON
-          if [ -f "$FILE" ]; then
-            echo "Updating existing file"
-          else
-            echo "{}" > "$FILE"
-          fi
+          git fetch origin $BRANCH:$BRANCH || true
+          git worktree add ../deploy-worktree $BRANCH
+
+          cp ../deploy-worktree/$FILE $FILE || echo "{}" > $FILE
+
 
           # Write digest under environment key
           jq --arg env "$ENV" \

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -212,7 +212,7 @@ jobs:
 
           # Write digest under environment key
           jq --arg env "$ENV" \
-            --arg digest "$DIGEST" \
+            --arg digest "$IMAGE_DIGEST" \
             --arg version_tag "$VERSION_TAG" \
             --arg image_tag "$IMAGE_TAG" \
             '.[$env] = {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}' \

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -189,7 +189,7 @@ jobs:
         if: ${{ inputs.WF_SHOW_COMMENT }}
         env:
           GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
-          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo"
+          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}"
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "✅ Deployed image: \`${{ steps.login-ecr.outputs.registry }}/${ECR_REPOSITORY}:${{ inputs.WF_IMAGE_TAG }}\`"
           gh pr comment ${{ github.event.pull_request.number }} --body "Segura o link dessa app review aí ó o/

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -6,6 +6,9 @@ on:
       WF_IMAGE_TAG:
         type: string
         required: true
+      WF_DIGEST_IMAGE:
+        type: string
+        required: true
       WF_ENV_TYPE_DEPLOY:
         type: string
         required: true
@@ -185,10 +188,28 @@ jobs:
       - name: Comment on PR with deployed image
         if: ${{ inputs.WF_SHOW_COMMENT }}
         env:
+          IMAGE_DIGEST: ${{inputs.WF_DIGEST_IMAGE}}
           GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
           ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo"
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "✅ Deployed image: \`${{ steps.login-ecr.outputs.registry }}/${ECR_REPOSITORY}:${{ inputs.WF_IMAGE_TAG }}\`"
+      - name: upsert .deploys/service.json
+        run: |
+          mkdir -p .deploys
+
+          FILE=".deploys/service.json"
+          SERVICE_NAME=$(node -p -e "require('./package.json').name")
+
+          if [ -f "$FILE" ]; then
+            echo "Updating $FILE"
+          else
+            echo "Creating $FILE"
+            echo '{}' > "$FILE"
+          fi
+
+          jq --arg image "$IMAGE_DIGEST" '.review = { "digest": $image }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+
+          cat "$FILE"
 
       - name: Open PR to main if needed
         if: ${{ inputs.WF_CREATE_PR_IN_MAIN }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Fetch environment from SSM
         uses: almerindo/action-env-from-aws-ssm@main
         with:
-          output: ./kube/${{ secrets.WF_KUBE_NAME }}-env-cm.yaml
+          output: ./.kube/${{ secrets.WF_KUBE_NAME }}-env-cm.yaml
           ssm-path: "/${{ inputs.WF_ENV_TYPE }}/${{ secrets.WF_SERVICE_NAME }}"
           format: configmap
         env:

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -224,7 +224,7 @@ jobs:
         if: ${{ inputs.WF_ENV_TYPE_DEPLOY == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: dev-deploy-state
+          name: service-${{ inputs.WF_SERVICE_NAME }}-dev-${{ github.event.pull_request.number || github.sha }}
           path: .deploys/service.json
 
       - name: Commit & Push deploy state (stg/prod)

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -232,21 +232,24 @@ jobs:
         env:
           BRANCH: "deploy-state"
           ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
+          FILE: ".deploys/service.json"
         run: |
-          fetch origin $BRANCH:$BRANCH || git worktree add ../deploy-worktree $BRANCH
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          # Cria diretório isolado para o worktree
+          git fetch origin $BRANCH:$BRANCH || true
+          git worktree add ../deploy-worktree $BRANCH
+
+          # Copia o service.json gerado
           cp "$FILE" ../deploy-worktree/$FILE
 
           cd ../deploy-worktree
 
-          git config user.name "github-actions"
-          git config user.email "actions@github.com"
-
-          git fetch origin $BRANCH:$BRANCH || git checkout --orphan $BRANCH
-          git switch $BRANCH
-
           git add "$FILE"
-          git commit -m "chore(ci): update digest for $ENV [skip ci]"
+          git commit -m "chore(ci): promote $ENV from dev to $ENV [skip ci]" || echo "⚠️ Nothing to commit"
           git push origin $BRANCH
+
 
       - name: Open PR to main if needed
         if: ${{ inputs.WF_CREATE_PR_IN_MAIN }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -245,8 +245,6 @@ jobs:
           git push origin $BRANCH
 
 
-          cat "$FILE"
-
       - name: Handle dev layer vs tracked environments
         if: ${{ inputs.WF_ENV_TYPE_DEPLOY == 'dev' }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -188,28 +188,44 @@ jobs:
       - name: Comment on PR with deployed image
         if: ${{ inputs.WF_SHOW_COMMENT }}
         env:
-          IMAGE_DIGEST: ${{inputs.WF_DIGEST_IMAGE}}
           GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
           ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo"
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "✅ Deployed image: \`${{ steps.login-ecr.outputs.registry }}/${ECR_REPOSITORY}:${{ inputs.WF_IMAGE_TAG }}\`"
       - name: upsert .deploys/service.json
+        env:
+          IMAGE_DIGEST: ${{inputs.WF_DIGEST_IMAGE}}
+          FILE: 'service.json'
+          ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
+          GITHUB_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
+          IMAGE_TAG: ${{ inputs.WF_IMAGE_TAG }}
+          VERSION_TAG: "${{ github.sha }}"
+
         run: |
-          mkdir -p .deploys
-
-          FILE=".deploys/service.json"
-          SERVICE_NAME=$(node -p -e "require('./package.json').name")
-
+          mkdir -p .deploys && cd .deploys
+          # Create or update JSON
           if [ -f "$FILE" ]; then
-            echo "Updating $FILE"
+            echo "Updating existing file"
           else
-            echo "Creating $FILE"
-            echo '{}' > "$FILE"
+            echo "{}" > "$FILE"
           fi
 
-          jq --arg image "$IMAGE_DIGEST" '.review = { "digest": $image }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+          # Write digest under environment key
+          jq --arg env "$ENV" \
+            --arg digest "$DIGEST" \
+            --arg version_tag "$VERSION_TAG" \
+            --arg image_tag "$IMAGE_TAG" \
+            '.[$env] = {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}' \
+            "$FILE" > tmp.json && mv tmp.json "$FILE"
 
           cat "$FILE"
+          
+          # Commit changes
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add "$FILE"
+          git commit -m "chore(ci): update digest for $ENV"
+          git push origin HEAD
 
       - name: Open PR to main if needed
         if: ${{ inputs.WF_CREATE_PR_IN_MAIN }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -1,8 +1,11 @@
-# This is a basic workflow to help you get started with Actions
 name: CI-K8-BASE
+
 on:
   workflow_call:
     inputs:
+      WF_IMAGE_TAG:
+        type: string
+        required: true
       WF_ENV_TYPE_DEPLOY:
         type: string
         required: true
@@ -51,14 +54,12 @@ on:
     secrets:
       WF_KUBE_TYPE:
         required: true
-
       WF_AWS_ACCESS_KEY_ID:
         required: true
       WF_AWS_SECRET_ACCESS_KEY:
         required: true
       WF_AWS_REGION:
         required: true
-
       WF_SERVICE_NAME:
         required: true
       WF_KUBE_NAME:
@@ -67,29 +68,23 @@ on:
         required: true
       WF_KUBE_DOMAIN_INTERNAL:
         required: true
-
       WF_GITHUB_TOKEN:
         required: true
-
       WF_WHITELIST_SOURCE_RANGE:
         required: false
 
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  setup:
-    name: preparing
+  deploy:
+    name: Deploy to Kubernetes
     runs-on: ubuntu-latest
-    environment: ${{inputs.WF_ENV_TYPE_DEPLOY}}
-    continue-on-error: false
-    # Steps represent a sequence of tasks that will be executed as part of the job
+    environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     steps:
-      - name: Checkout
+      - name: Checkout source
         uses: actions/checkout@v4
         with:
-          persist-credentials: false
           fetch-depth: 0
 
-      - name: Checkout tools repo
+      - name: Checkout kube manifests
         uses: actions/checkout@v4
         with:
           ref: v1.11.0
@@ -98,7 +93,7 @@ jobs:
           path: .kube
           persist-credentials: false
 
-      - name: Configure AWS credentials
+      - name: Setup AWS & IAM
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.WF_AWS_ACCESS_KEY_ID }}
@@ -110,7 +105,7 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Creating configmap.yaml from aws parameter store
+      - name: Fetch environment from SSM
         uses: almerindo/action-env-from-aws-ssm@main
         with:
           output: .kube/${{ secrets.WF_KUBE_NAME }}-env-cm.yaml
@@ -121,127 +116,71 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.WF_AWS_REGION }}
 
-      - name: Override kubefiles
-        run: |
-          FILE=setup/.kube
-          if [[ -d "$FILE" ]]; then
-            echo "$FILE EXIST!" 
-            cp -avf setup/.kube/*.yaml .kube/
-            echo "Kubefiles Override FINISHED" 
-          fi
-
       - name: Setup kubectl
         run: |
           curl -LO "https://dl.k8s.io/release/v1.30.6/bin/linux/amd64/kubectl"
-          chmod u+x kubectl
-          sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+          chmod +x kubectl
+          sudo mv kubectl /usr/local/bin/
           curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.26/aws-iam-authenticator_0.6.26_linux_amd64
-          chmod u+x aws-iam-authenticator
+          chmod +x aws-iam-authenticator
+          sudo mv aws-iam-authenticator /usr/local/bin/
 
-      - name: Defining envs variables for kube
+      - name: Prepare envs
         run: |
-          WF_KUBE_MEMORY_LIMIT=${{ inputs.WF_KUBE_MEMORY_LIMIT }}
+          echo "WF_KUBE_MEMORY_LIMIT=${{ inputs.WF_KUBE_MEMORY_LIMIT || inputs.WF_KUBE_MEMORY_REQUEST }}" >> $GITHUB_ENV
 
-          # Check if B is null or empty
-          if [ -z "$WF_KUBE_MEMORY_LIMIT" ]; then
-              # If WF_KUBE_MEMORY_LIMIT is null or empty, assign the value of WF_KUBE_MEMORY_REQUEST to WF_KUBE_MEMORY_LIMIT
-              WF_KUBE_MEMORY_LIMIT="${{ inputs.WF_KUBE_MEMORY_REQUEST }}"
-          fi
-
-          echo "WF_KUBE_MEMORY_LIMIT=$WF_KUBE_MEMORY_LIMIT" >> $GITHUB_ENV
-      - name: Remove WF_KUBE_CPU_LIMIT when is null
-        if: ${{inputs.WF_KUBE_CPU_LIMIT == ''}}
+      - name: Render manifests with envsubst
         run: |
-          sed -i '/KUBE_CPU_LIMIT/d' ./.kube/deployment-new.yaml
-      - name: Kubernetes Deploy
+          mkdir -p rendered
+          for file in .kube/*.yaml; do
+            envsubst < "$file" > "rendered/$(basename $file)"
+          done
+
+      - name: Apply manifests
         env:
-          KUBE_NAME: ${{ secrets.WF_KUBE_NAME }}
-          KUBE_DOMAIN: ${{ secrets.WF_KUBE_DOMAIN }}
-          KUBE_DOMAIN_INTERNAL: ${{ secrets.WF_KUBE_DOMAIN_INTERNAL }}
-          KUBECONFIG: .kube/config-${{secrets.WF_KUBE_TYPE}}.yaml
-          KUBEDEPLOYMENT: .kube/deployment-${{inputs.WF_KUBE_DEPLOYMENT}}.yaml
+          KUBECONFIG: .kube/config-${{ secrets.WF_KUBE_TYPE }}.yaml
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE}}_repo"
-          VERSION_TAG: ${{ github.sha }}
-          KUBE_MIN_REPLICAS: ${{ inputs.WF_KUBE_MIN_REPLICAS }}
-          PUBLIC_HOST: ${{ inputs.WF_PUBLIC_HOST }}
-          KUBE_MAX_REPLICAS: ${{ inputs.WF_KUBE_MAX_REPLICAS }}
-          KUBE_MEMORY_LIMIT: ${{ env.WF_KUBE_MEMORY_LIMIT }}
-          KUBE_MEMORY_REQUEST: ${{ inputs.WF_KUBE_MEMORY_REQUEST }}
-          KUBE_CPU_LIMIT: ${{ inputs.WF_KUBE_CPU_LIMIT }}
-          KUBE_CPU_REQUEST: ${{ inputs.WF_KUBE_CPU_REQUEST }}
-          KUBE_NODE_GROUP: ${{ inputs.WF_KUBE_NODE_GROUP }}
-        run: |
-          echo "Export must be a first line"
-          export PATH=$PATH:$PWD
-          kubectl version
-          echo "Replacing envs from kube manifests"
-          echo "public host ${PUBLIC_HOST}"
-          cat .kube/namespace.yaml | envsubst > namespace.yaml
-          cat .kube/${KUBE_NAME}-env-cm.yaml | envsubst > ${KUBE_NAME}-env-cm.yaml
-          cat ${KUBEDEPLOYMENT} | envsubst > deployment.yaml
-          cat .kube/service.yaml | envsubst > service.yaml
-          cat .kube/ingress.yaml | envsubst > ingress.yaml
-          cat .kube/ingress-internal.yaml | envsubst > ingress-internal.yaml
-          cat .kube/hpa.yaml | envsubst > hpa.yaml
-          echo "Applying namespace"
-          kubectl apply -f namespace.yaml
-          echo "Applying configmap"
-          kubectl apply -f ${KUBE_NAME}-env-cm.yaml
-          echo "Applying deployment"
-          kubectl apply -f deployment.yaml
-          echo "Applying rollout"
-          kubectl rollout restart deployment/${KUBE_NAME} -n ${KUBE_NAME}
-          kubectl rollout status deployment/${KUBE_NAME} -n ${KUBE_NAME}
-          echo "Applying hpa"
-          kubectl apply -f hpa.yaml
-          echo "Applying service"
-          kubectl apply -f service.yaml
-          echo "Applying ingress"
-          kubectl apply -f ingress.yaml
-          echo "Applying ingress internal"
-          kubectl apply -f ingress-internal.yaml
-          echo "URL: https://${KUBE_NAME}${KUBE_DOMAIN}"
-
-      - name: Setting the service visibility
-        if: ${{ inputs.WF_IS_INTERNAL }}
-        id: "set-visibility"
-        env:
-          KUBECONFIG: .kube/config-${{secrets.WF_KUBE_TYPE}}.yaml
+          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo"
+          VERSION_TAG: ${{ inputs.WF_IMAGE_TAG }}
           KUBE_NAME: ${{ secrets.WF_KUBE_NAME }}
-          WHITELIST_SOURCE_RANGE: ${{ secrets.WF_WHITELIST_SOURCE_RANGE}}
         run: |
-          echo "Setting thee path"
           export PATH=$PATH:$PWD
+          kubectl apply -f rendered/namespace.yaml
+          kubectl apply -f .kube/${KUBE_NAME}-env-cm.yaml
+          kubectl apply -f rendered/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml
+          kubectl rollout restart deployment/$KUBE_NAME -n $KUBE_NAME
+          kubectl rollout status deployment/$KUBE_NAME -n $KUBE_NAME
+          kubectl apply -f rendered/hpa.yaml
+          kubectl apply -f rendered/service.yaml
+          kubectl apply -f rendered/ingress.yaml
+          kubectl apply -f rendered/ingress-internal.yaml
+
+      - name: Set service visibility (internal ingress whitelist)
+        if: ${{ inputs.WF_IS_INTERNAL }}
+        env:
+          KUBECONFIG: .kube/config-${{ secrets.WF_KUBE_TYPE }}.yaml
+          KUBE_NAME: ${{ secrets.WF_KUBE_NAME }}
+          WHITELIST_SOURCE_RANGE: ${{ secrets.WF_WHITELIST_SOURCE_RANGE }}
+        run: |
           kubectl -n ${KUBE_NAME} annotate --overwrite ingress ${KUBE_NAME} ingress.kubernetes.io/whitelist-source-range=${WHITELIST_SOURCE_RANGE}
           kubectl -n ${KUBE_NAME} annotate --overwrite ingress ${KUBE_NAME} kubernetes.io/whitelist-source-range=${WHITELIST_SOURCE_RANGE}
 
-      - name: Create comment
+      - name: Comment on PR with deployed image
         if: ${{ inputs.WF_SHOW_COMMENT }}
-        id: "create-comment"
+        env:
+          GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
+          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo"
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --body "✅ Deployed image: \`${{ steps.login-ecr.outputs.registry }}/${ECR_REPOSITORY}:${{ inputs.WF_IMAGE_TAG }}\`"
+
+      - name: Open PR to main if needed
+        if: ${{ inputs.WF_CREATE_PR_IN_MAIN }}
         env:
           GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body "Segura o link dessa app review aí ó o/
-            -   URL: https://${{ secrets.WF_KUBE_NAME }}${{ secrets.WF_KUBE_DOMAIN }}"
-
-      - name: Check if there are commits between staging to main
-        id: check_commits
-        if: ${{ inputs.WF_CREATE_PR_IN_MAIN}}
-        run: |
-          if [ "$(git rev-list --count 'origin/main..HEAD')" -eq 0 ]; then
-            echo "No commits to create pull request for."
-            echo "commits_head_main=false" >> $GITHUB_OUTPUT
+          git fetch origin main
+          if [ "$(git rev-list origin/main..HEAD --count)" -gt 0 ]; then
+            gh pr create --base main --title "Deploy to production" --body "Auto-generated PR to promote to production"
           else
-            echo "Commits found. Ready to create pull request."
-            echo "commits_head_main=true" >> $GITHUB_OUTPUT
+            echo "No new commits to promote"
           fi
-
-      - name: Create Pull Request for prod
-        if: ${{ inputs.WF_CREATE_PR_IN_MAIN && steps.check_commits.outputs.commits_head_main == 'true'}}
-        id: "open-pr"
-        env:
-          GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
-        run: |
-          echo "Creating the PR Deply in prod"
-          gh pr edit stage -b "Pull request body" -t 'Deploy in prod'  && gh pr reopen stage || gh pr create --base "main" --title "Deploy in prod" --body "Pull request body"

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -136,10 +136,6 @@ jobs:
             envsubst < "$file" > "rendered/$(basename $file)"
           done
 
-      - name: Validate manifests
-        run: |
-          kubectl apply --dry-run=client -f rendered/
-
       - name: Apply manifests
         env:
           KUBECONFIG: .kube/config-${{ secrets.WF_KUBE_TYPE }}.yaml

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -224,7 +224,7 @@ jobs:
         if: ${{ inputs.WF_ENV_TYPE_DEPLOY == 'dev' }}
         uses: actions/upload-artifact@v4
         with:
-          name: service-${{ inputs.WF_SERVICE_NAME }}-dev-${{ github.event.pull_request.number || github.sha }}
+          name: service-${{ secrets.WF_SERVICE_NAME }}-dev-${{ github.event.pull_request.number || github.sha }}
           path: .deploys/service.json
 
       - name: Commit & Push deploy state (stg/prod)

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -130,6 +130,23 @@ jobs:
           echo "WF_KUBE_MEMORY_LIMIT=${{ inputs.WF_KUBE_MEMORY_LIMIT || inputs.WF_KUBE_MEMORY_REQUEST }}" >> $GITHUB_ENV
 
       - name: Render manifests with envsubst
+        env:
+          KUBE_NAME: ${{ secrets.WF_KUBE_NAME }}
+          KUBE_DOMAIN: ${{ secrets.WF_KUBE_DOMAIN }}
+          KUBE_DOMAIN_INTERNAL: ${{ secrets.WF_KUBE_DOMAIN_INTERNAL }}
+          KUBECONFIG: .kube/config-${{secrets.WF_KUBE_TYPE}}.yaml
+          KUBEDEPLOYMENT: .kube/deployment-${{inputs.WF_KUBE_DEPLOYMENT}}.yaml
+          KUBE_MIN_REPLICAS: ${{ inputs.WF_KUBE_MIN_REPLICAS }}
+          PUBLIC_HOST: ${{ inputs.WF_PUBLIC_HOST }}
+          KUBE_MAX_REPLICAS: ${{ inputs.WF_KUBE_MAX_REPLICAS }}
+          KUBE_MEMORY_LIMIT: ${{ env.WF_KUBE_MEMORY_LIMIT }}
+          KUBE_MEMORY_REQUEST: ${{ inputs.WF_KUBE_MEMORY_REQUEST }}
+          KUBE_CPU_LIMIT: ${{ inputs.WF_KUBE_CPU_LIMIT }}
+          KUBE_CPU_REQUEST: ${{ inputs.WF_KUBE_CPU_REQUEST }}
+          KUBE_NODE_GROUP: ${{ inputs.WF_KUBE_NODE_GROUP }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}"
+          VERSION_TAG: ${{ inputs.WF_IMAGE_TAG }}
         run: |
           mkdir -p rendered
           for file in .kube/*.yaml; do

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -131,7 +131,10 @@ jobs:
       - name: Prepare envs
         run: |
           echo "WF_KUBE_MEMORY_LIMIT=${{ inputs.WF_KUBE_MEMORY_LIMIT || inputs.WF_KUBE_MEMORY_REQUEST }}" >> $GITHUB_ENV
-
+      - name: Remove WF_KUBE_CPU_LIMIT when is null
+        if: ${{inputs.WF_KUBE_CPU_LIMIT == ''}}
+        run: |
+          sed -i '/KUBE_CPU_LIMIT/d' ./.kube/deployment-new.yaml
       - name: Render manifests with envsubst
         env:
           KUBE_NAME: ${{ secrets.WF_KUBE_NAME }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -131,14 +131,14 @@ jobs:
 
       - name: Render manifests with envsubst
         run: |
-          mkdir -p .kube
+          mkdir -p rendered
           for file in .kube/*.yaml; do
-            envsubst < "$file" > ".kube/$(basename $file)"
+            envsubst < "$file" > "rendered/$(basename $file)"
           done
 
       - name: Validate manifests
         run: |
-          kubectl apply --dry-run=client -f .kube/
+          kubectl apply --dry-run=client -f rendered/
 
       - name: Apply manifests
         env:
@@ -149,16 +149,16 @@ jobs:
           KUBE_NAME: ${{ secrets.WF_KUBE_NAME }}
         run: |
           export PATH=$PATH:$PWD
-          kubectl apply -f .kube/namespace.yaml
-          kubectl apply -f .kube/${KUBE_NAME}-env-cm.yaml
-          kubectl apply -f .kube/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml
-          DEPLOY_NAME=$(yq e '.metadata.name' .kube/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml)
+          kubectl apply -f rendered/namespace.yaml
+          kubectl apply -f rendered/${KUBE_NAME}-env-cm.yaml
+          kubectl apply -f rendered/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml
+          DEPLOY_NAME=$(yq e '.metadata.name' rendered/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml)
           kubectl rollout restart deployment/$DEPLOY_NAME -n $KUBE_NAME
           kubectl rollout status deployment/$DEPLOY_NAME -n $KUBE_NAME
-          kubectl apply -f .kube/hpa.yaml
-          kubectl apply -f .kube/service.yaml
-          kubectl apply -f .kube/ingress.yaml
-          kubectl apply -f .kube/ingress-internal.yaml
+          kubectl apply -f rendered/hpa.yaml
+          kubectl apply -f rendered/service.yaml
+          kubectl apply -f rendered/ingress.yaml
+          kubectl apply -f rendered/ingress-internal.yaml
 
       - name: Set service visibility (internal ingress whitelist)
         if: ${{ inputs.WF_IS_INTERNAL }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -233,6 +233,11 @@ jobs:
           BRANCH: "deploy-state"
           ENV: "${{ inputs.WF_ENV_TYPE_DEPLOY }}"
         run: |
+          it fetch origin $BRANCH:$BRANCH || git worktree add ../deploy-worktree $BRANCH
+          cp "$FILE" ../deploy-worktree/$FILE
+
+          cd ../deploy-worktree
+          
           git config user.name "github-actions"
           git config user.email "actions@github.com"
 

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Fetch environment from SSM
         uses: almerindo/action-env-from-aws-ssm@main
         with:
-          output: .kube/${{ secrets.WF_KUBE_NAME }}-env-cm.yaml
+          output: ./kube/${{ secrets.WF_KUBE_NAME }}-env-cm.yaml
           ssm-path: "/${{ inputs.WF_ENV_TYPE }}/${{ secrets.WF_SERVICE_NAME }}"
           format: configmap
         env:
@@ -131,29 +131,34 @@ jobs:
 
       - name: Render manifests with envsubst
         run: |
-          mkdir -p rendered
+          mkdir -p .kube
           for file in .kube/*.yaml; do
-            envsubst < "$file" > "rendered/$(basename $file)"
+            envsubst < "$file" > ".kube/$(basename $file)"
           done
+
+      - name: Validate manifests
+        run: |
+          kubectl apply --dry-run=client -f .kube/
 
       - name: Apply manifests
         env:
           KUBECONFIG: .kube/config-${{ secrets.WF_KUBE_TYPE }}.yaml
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo"
+          ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}"
           VERSION_TAG: ${{ inputs.WF_IMAGE_TAG }}
           KUBE_NAME: ${{ secrets.WF_KUBE_NAME }}
         run: |
           export PATH=$PATH:$PWD
-          kubectl apply -f rendered/namespace.yaml
+          kubectl apply -f .kube/namespace.yaml
           kubectl apply -f .kube/${KUBE_NAME}-env-cm.yaml
-          kubectl apply -f rendered/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml
-          kubectl rollout restart deployment/$KUBE_NAME -n $KUBE_NAME
-          kubectl rollout status deployment/$KUBE_NAME -n $KUBE_NAME
-          kubectl apply -f rendered/hpa.yaml
-          kubectl apply -f rendered/service.yaml
-          kubectl apply -f rendered/ingress.yaml
-          kubectl apply -f rendered/ingress-internal.yaml
+          kubectl apply -f .kube/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml
+          DEPLOY_NAME=$(yq e '.metadata.name' .kube/deployment-${{ inputs.WF_KUBE_DEPLOYMENT }}.yaml)
+          kubectl rollout restart deployment/$DEPLOY_NAME -n $KUBE_NAME
+          kubectl rollout status deployment/$DEPLOY_NAME -n $KUBE_NAME
+          kubectl apply -f .kube/hpa.yaml
+          kubectl apply -f .kube/service.yaml
+          kubectl apply -f .kube/ingress.yaml
+          kubectl apply -f .kube/ingress-internal.yaml
 
       - name: Set service visibility (internal ingress whitelist)
         if: ${{ inputs.WF_IS_INTERNAL }}
@@ -163,7 +168,6 @@ jobs:
           WHITELIST_SOURCE_RANGE: ${{ secrets.WF_WHITELIST_SOURCE_RANGE }}
         run: |
           kubectl -n ${KUBE_NAME} annotate --overwrite ingress ${KUBE_NAME} ingress.kubernetes.io/whitelist-source-range=${WHITELIST_SOURCE_RANGE}
-          kubectl -n ${KUBE_NAME} annotate --overwrite ingress ${KUBE_NAME} kubernetes.io/whitelist-source-range=${WHITELIST_SOURCE_RANGE}
 
       - name: Comment on PR with deployed image
         if: ${{ inputs.WF_SHOW_COMMENT }}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -192,6 +192,8 @@ jobs:
           ECR_REPOSITORY: "${{ secrets.WF_SERVICE_NAME }}_${{ inputs.WF_ENV_TYPE }}_repo"
         run: |
           gh pr comment ${{ github.event.pull_request.number }} --body "✅ Deployed image: \`${{ steps.login-ecr.outputs.registry }}/${ECR_REPOSITORY}:${{ inputs.WF_IMAGE_TAG }}\`"
+          gh pr comment ${{ github.event.pull_request.number }} --body "Segura o link dessa app review aí ó o/
+            -   URL: https://${{ secrets.WF_KUBE_NAME }}${{ secrets.WF_KUBE_DOMAIN }}"
       - name: upsert .deploys/service.json
         env:
           IMAGE_DIGEST: ${{inputs.WF_DIGEST_IMAGE}}

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -220,7 +220,7 @@ jobs:
             --arg digest "$IMAGE_DIGEST" \
             --arg version_tag "$VERSION_TAG" \
             --arg image_tag "$IMAGE_TAG" \
-            '.[$env] = {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}' \
+            '. + {($env): {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}}' \
             "$FILE" > tmp.json && mv tmp.json "$FILE"
 
           cat "$FILE"

--- a/.github/workflows/ci_k8_base.yml
+++ b/.github/workflows/ci_k8_base.yml
@@ -135,7 +135,7 @@ jobs:
           for file in .kube/*.yaml; do
             envsubst < "$file" > "rendered/$(basename $file)"
           done
-
+          cat rendered/namespace.yaml
       - name: Apply manifests
         env:
           KUBECONFIG: .kube/config-${{ secrets.WF_KUBE_TYPE }}.yaml

--- a/.github/workflows/ci_k8_undeploy_base.yml
+++ b/.github/workflows/ci_k8_undeploy_base.yml
@@ -3,9 +3,6 @@ name: CI-K8-BASE-UNDEPLOY
 on:
   workflow_call:
     inputs:
-      WF_ENV_TYPE:
-        type: string
-        required: true
       WF_ENV_TYPE_DEPLOY:
         type: string
         required: true

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           SERVICE_NAME=$(node -p -e "require('./package.json').name")
           echo "servicename=$SERVICE_NAME" >> $GITHUB_OUTPUT
+          echo 'artifact' ${{ inputs.ARTIFACT_ID }}
 
       - name: Download dev artifact (if FROM_ENV is dev)
         if: ${{ inputs.FROM_ENV == 'dev' }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -59,9 +59,10 @@ jobs:
           fi
 
           cat from.json
-          DIGEST=$(jq -r '.digest' from.json)
-          VERSION_TAG=$(jq -r '.version_tag' from.json)
-          IMAGE_TAG=$(jq -r '.image_tag' from.json)
+          DIGEST=$(jq -r '.dev.digest' from.json)
+          VERSION_TAG=$(jq -r '.dev.version_tag' from.json)
+          IMAGE_TAG=$(jq -r '.dev.image_tag' from.json)
+
 
           if [[ -z "$DIGEST" || "$DIGEST" == "null" ]]; then
             echo "❌ Missing digest for ${{ inputs.FROM_ENV }}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -103,3 +103,25 @@ jobs:
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+      - name: Retag image in ECR
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.NEW_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.NEW_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-east-1
+          REPO: ${{ steps.serviceName.outputs.service_name }}
+          FROM_TAG: ${{ steps.promote.outputs.image_tag }}
+          TO_TAG: ${{ inputs.TO_ENV }}
+          DIGEST: ${{ steps.promote.outputs.digest }}
+        run: |
+          echo "🔁 Retagging image in ECR: $REPO from $FROM_TAG (digest: $DIGEST) to $TO_TAG"
+
+          aws ecr put-image \
+            --repository-name "$REPO" \
+            --image-tag "$TO_TAG" \
+            --image-manifest "$(aws ecr batch-get-image \
+              --repository-name "$REPO" \
+              --image-ids imageDigest=$DIGEST \
+              --query 'images[0].imageManifest' \
+              --output text)"
+
+          echo "✅ Image retagged in ECR: $REPO:$TO_TAG"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -22,6 +22,11 @@ jobs:
     environment: ${{ inputs.TO_ENV }}
 
     steps:
+      - name: Checkout deploy-state branch
+        uses: actions/checkout@v4
+        with:
+            ref: deploy-state
+            token: ${{ secrets.WF_GITHUB_TOKEN }}
       - name: Getting SERVICE_NAME
         id: serviceName
         run: |
@@ -35,11 +40,6 @@ jobs:
           name: service-${{ steps.serviceName.outputs.servicename }}-dev-${{ inputs.ARTIFACT_ID }}
           path: dev-meta
 
-      - name: Checkout deploy-state branch
-        uses: actions/checkout@v4
-        with:
-          ref: deploy-state
-          token: ${{ secrets.WF_GITHUB_TOKEN }}
 
       - name: Ensure .deploys/service.json exists
         run: |

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -117,28 +117,32 @@ jobs:
           aws-secret-access-key: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.WF_AWS_REGION }}
           role-session-name:  ${{ steps.serviceName.outputs.service_name }}_GitHubActions
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
-      - name: Retag image in ECR
+      - name: Retag image in ECR using AWS CLI
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.NEW_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.NEW_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: us-east-1
           REPO: ${{ steps.serviceName.outputs.service_name }}
-          FROM_TAG: ${{ steps.promote.outputs.image_tag }}
-          TO_TAG: ${{ inputs.TO_ENV }}
           DIGEST: ${{ steps.promote.outputs.digest }}
+          TO_TAG: ${{ inputs.TO_ENV }}
         run: |
-          echo "🔁 Retagging image in ECR: $REPO from $FROM_TAG (digest: $DIGEST) to $TO_TAG"
+          echo "🔁 Retagging image in ECR: $REPO from digest $DIGEST to tag $TO_TAG"
+          
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          REGION=${{ env.AWS_REGION || 'us-east-1' }}
+          MANIFEST=$(aws ecr batch-get-image \
+            --repository-name "$REPO" \
+            --image-ids imageDigest="$DIGEST" \
+            --query 'images[0].imageManifest' \
+            --output text)
 
+          if [[ -z "$MANIFEST" || "$MANIFEST" == "null" ]]; then
+            echo "❌ Failed to retrieve image manifest for digest: $DIGEST"
+            exit 1
+          fi
+
+          echo "📤 Putting image with new tag: $TO_TAG"
           aws ecr put-image \
             --repository-name "$REPO" \
             --image-tag "$TO_TAG" \
-            --image-manifest "$(aws ecr batch-get-image \
-              --repository-name "$REPO" \
-              --image-ids imageDigest=$DIGEST \
-              --query 'images[0].imageManifest' \
-              --output text)"
+            --image-manifest "$MANIFEST"
 
-          echo "✅ Image retagged in ECR: $REPO:$TO_TAG"
+          echo "✅ Retag successful: $REPO:$TO_TAG"
+

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -24,13 +24,13 @@ on:
         description: "The image digest"
         value: ${{ jobs.promote.outputs.digest }}
       image_tag:
-        description: "The image digest"
+        description: "The image tag"
         value: ${{ jobs.promote.outputs.image_tag }}
       version_tag:
-        description: "The image digest"
+        description: "The version tag (commit sha)"
         value: ${{ jobs.promote.outputs.version_tag }}
       service_name:
-        description: "The image digest"
+        description: "The service name"
         value: ${{ jobs.promote.outputs.service_name }}
 
 jobs:
@@ -38,18 +38,26 @@ jobs:
     runs-on: ubuntu-latest
     environment: ${{ inputs.TO_ENV }}
 
+    outputs:
+      digest: ${{ steps.promote.outputs.digest }}
+      image_tag: ${{ steps.promote.outputs.image_tag }}
+      version_tag: ${{ steps.promote.outputs.version_tag }}
+      service_name: ${{ steps.serviceName.outputs.service_name }}
+
     steps:
       - name: Checkout deploy-state branch
         uses: actions/checkout@v4
         with:
-            ref: deploy-state
-            token: ${{ secrets.WF_GITHUB_TOKEN }}
-      - name: Getting SERVICE_NAME
+          ref: deploy-state
+          token: ${{ secrets.WF_GITHUB_TOKEN }}
+
+      - name: Get service name
         id: serviceName
         run: |
           SERVICE_NAME=$(node -p -e "require('./package.json').name")
           echo "service_name=$SERVICE_NAME" >> $GITHUB_OUTPUT
-      - name: Download dev artifact (if FROM_ENV is dev)
+
+      - name: Download dev artifact (only if FROM_ENV is dev)
         if: ${{ inputs.FROM_ENV == 'dev' }}
         uses: actions/download-artifact@v4
         with:
@@ -58,13 +66,13 @@ jobs:
           github-token: ${{ secrets.WF_GITHUB_TOKEN }}
           run-id: ${{ inputs.ARTIFACT_RUN_ID }}
 
-
       - name: Ensure .deploys/service.json exists
         run: |
           mkdir -p .deploys
           [ -f .deploys/service.json ] || echo '{}' > .deploys/service.json
 
-      - name: Load promotion data
+      - name: Promote image metadata
+        id: promote
         run: |
           if [[ "${{ inputs.FROM_ENV }}" == "dev" ]]; then
             cp dev-meta/service.json from.json
@@ -72,11 +80,12 @@ jobs:
             jq --arg env "${{ inputs.FROM_ENV }}" '.[$env]' .deploys/service.json > from.json
           fi
 
+          echo "📦 Loaded metadata from ${{ inputs.FROM_ENV }}"
           cat from.json
-          DIGEST=$(jq -r '.dev.digest' from.json)
-          VERSION_TAG=$(jq -r '.dev.version_tag' from.json)
-          IMAGE_TAG=$(jq -r '.dev.image_tag' from.json)
 
+          DIGEST=$(jq -r '.digest' from.json)
+          VERSION_TAG=$(jq -r '.version_tag' from.json)
+          IMAGE_TAG=$(jq -r '.image_tag' from.json)
 
           if [[ -z "$DIGEST" || "$DIGEST" == "null" ]]; then
             echo "❌ Missing digest for ${{ inputs.FROM_ENV }}"
@@ -90,10 +99,7 @@ jobs:
              '.[$env] = {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}' \
              .deploys/service.json > tmp.json && mv tmp.json .deploys/service.json
 
+          echo "✅ Promoted ${{ steps.serviceName.outputs.service_name }} from ${{ inputs.FROM_ENV }} to ${{ inputs.TO_ENV }}"
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-
-          echo "✅ Promoted ${{
-            steps.serviceName.outputs.servicename
-          }} from ${{ inputs.FROM_ENV }} to ${{ inputs.TO_ENV }}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -12,6 +12,9 @@ on:
       ARTIFACT_ID:
         type: string
         required: false  # only used for dev
+      ARTIFACT_RUN_ID:
+        type: string
+        required: false
     secrets:
       WF_GITHUB_TOKEN:
         required: true
@@ -38,6 +41,8 @@ jobs:
         with:
           name: service-${{ steps.serviceName.outputs.servicename }}-dev-${{ inputs.ARTIFACT_ID }}
           path: dev-meta
+          github-token: ${{ secrets.WF_GITHUB_TOKEN }}
+          run-id: ${{ inputs.ARTIFACT_RUN_ID }}
 
 
       - name: Ensure .deploys/service.json exists

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -18,6 +18,12 @@ on:
     secrets:
       WF_GITHUB_TOKEN:
         required: true
+      WF_AWS_ACCESS_KEY_ID:
+        required: true
+      WF_AWS_SECRET_ACCESS_KEY:
+        required: true
+      WF_AWS_REGION:
+        required: true
 
     outputs:
       digest:
@@ -110,7 +116,7 @@ jobs:
           aws-access-key-id: ${{ secrets.WF_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.WF_AWS_REGION }}
-          role-session-name: ${{ secrets.WF_SERVICE_NAME }}_GitHubActions
+          role-session-name:  ${{ steps.serviceName.outputs.service_name }}_GitHubActions
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -83,7 +83,7 @@ jobs:
           if [[ "${{ inputs.FROM_ENV }}" == "dev" ]]; then
             cp dev-meta/service.json from.json
           else
-            jq --arg env "${{ inputs.FROM_ENV }}" '.[$env]' .deploys/service.json > from.json
+            cp .deploys/service.json from.json
           fi
 
           echo "📦 Loaded metadata from ${{ inputs.FROM_ENV }}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -126,7 +126,21 @@ jobs:
           echo "🔁 Retagging image in ECR: $REPO from digest $DIGEST to tag $TO_TAG"
           
           ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
-          REGION=${{ env.AWS_REGION || 'us-east-1' }}
+          REGION=***
+
+          # Check if tag already exists and matches digest
+          EXISTING_DIGEST=$(aws ecr describe-images \
+            --repository-name "$REPO" \
+            --image-ids imageTag="$TO_TAG" \
+            --query 'imageDetails[0].imageDigest' \
+            --output text 2>/dev/null)
+
+          if [[ "$EXISTING_DIGEST" == "$DIGEST" ]]; then
+            echo "✅ Tag '$TO_TAG' already points to digest '$DIGEST'. Skipping re-tag."
+            exit 0
+          fi
+
+          # Fetch image manifest
           MANIFEST=$(aws ecr batch-get-image \
             --repository-name "$REPO" \
             --image-ids imageDigest="$DIGEST" \
@@ -138,6 +152,7 @@ jobs:
             exit 1
           fi
 
+          # Put image with new tag
           echo "📤 Putting image with new tag: $TO_TAG"
           aws ecr put-image \
             --repository-name "$REPO" \
@@ -145,4 +160,5 @@ jobs:
             --image-manifest "$MANIFEST"
 
           echo "✅ Retag successful: $REPO:$TO_TAG"
+
 

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -103,6 +103,10 @@ jobs:
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+      
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
       - name: Retag image in ECR
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.NEW_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -32,8 +32,6 @@ jobs:
         run: |
           SERVICE_NAME=$(node -p -e "require('./package.json').name")
           echo "servicename=$SERVICE_NAME" >> $GITHUB_OUTPUT
-          echo 'artifact' ${{ inputs.ARTIFACT_ID }}
-
       - name: Download dev artifact (if FROM_ENV is dev)
         if: ${{ inputs.FROM_ENV == 'dev' }}
         uses: actions/download-artifact@v4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -104,6 +104,13 @@ jobs:
           echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
       
+      - name: Setup AWS & IAM
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.WF_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.WF_AWS_REGION }}
+          role-session-name: ${{ secrets.WF_SERVICE_NAME }}_GitHubActions
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -29,6 +29,9 @@ on:
       version_tag:
         description: "The image digest"
         value: ${{ jobs.promote.outputs.version_tag }}
+      service_name:
+        description: "The image digest"
+        value: ${{ jobs.promote.outputs.service_name }}
 
 jobs:
   promote:
@@ -45,12 +48,12 @@ jobs:
         id: serviceName
         run: |
           SERVICE_NAME=$(node -p -e "require('./package.json').name")
-          echo "servicename=$SERVICE_NAME" >> $GITHUB_OUTPUT
+          echo "service_name=$SERVICE_NAME" >> $GITHUB_OUTPUT
       - name: Download dev artifact (if FROM_ENV is dev)
         if: ${{ inputs.FROM_ENV == 'dev' }}
         uses: actions/download-artifact@v4
         with:
-          name: service-${{ steps.serviceName.outputs.servicename }}-dev-${{ inputs.ARTIFACT_ID }}
+          name: service-${{ steps.serviceName.outputs.service_name }}-dev-${{ inputs.ARTIFACT_ID }}
           path: dev-meta
           github-token: ${{ secrets.WF_GITHUB_TOKEN }}
           run-id: ${{ inputs.ARTIFACT_RUN_ID }}
@@ -90,7 +93,7 @@ jobs:
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
-          
+
           echo "✅ Promoted ${{
             steps.serviceName.outputs.servicename
           }} from ${{ inputs.FROM_ENV }} to ${{ inputs.TO_ENV }}"

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -19,6 +19,17 @@ on:
       WF_GITHUB_TOKEN:
         required: true
 
+    outputs:
+      digest:
+        description: "The image digest"
+        value: ${{ jobs.promote.outputs.digest }}
+      image_tag:
+        description: "The image digest"
+        value: ${{ jobs.promote.outputs.image_tag }}
+      version_tag:
+        description: "The image digest"
+        value: ${{ jobs.promote.outputs.version_tag }}
+
 jobs:
   promote:
     runs-on: ubuntu-latest
@@ -76,14 +87,10 @@ jobs:
              '.[$env] = {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}' \
              .deploys/service.json > tmp.json && mv tmp.json .deploys/service.json
 
+          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          echo "version_tag=$VERSION_TAG" >> $GITHUB_OUTPUT
+          echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+          
           echo "✅ Promoted ${{
             steps.serviceName.outputs.servicename
           }} from ${{ inputs.FROM_ENV }} to ${{ inputs.TO_ENV }}"
-
-      - name: Commit and push promotion
-        run: |
-          git config user.name "github-actions"
-          git config user.email "actions@github.com"
-          git add .deploys/service.json
-          git commit -m "chore(ci): promote ${{ steps.serviceName.outputs.servicename }} from ${{ inputs.FROM_ENV }} to ${{ inputs.TO_ENV }} [skip ci]" || echo "Nothing to commit"
-          git push origin deploy-state

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -94,7 +94,7 @@ jobs:
 
           jq --arg env "${{ inputs.TO_ENV }}" \
              --arg digest "$DIGEST" \
-             --arg version_tag "$VERSION_TAG" \
+             --arg version_tag "${{ inputs.TO_ENV }}" \
              --arg image_tag "$IMAGE_TAG" \
              '.[$env] = {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}' \
              .deploys/service.json > tmp.json && mv tmp.json .deploys/service.json

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,84 @@
+name: promote
+
+on:
+  workflow_call:
+    inputs:
+      FROM_ENV:
+        type: string
+        required: true
+      TO_ENV:
+        type: string
+        required: true
+      ARTIFACT_ID:
+        type: string
+        required: false  # only used for dev
+    secrets:
+      WF_GITHUB_TOKEN:
+        required: true
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.TO_ENV }}
+
+    steps:
+      - name: Getting SERVICE_NAME
+        id: serviceName
+        run: |
+          SERVICE_NAME=$(node -p -e "require('./package.json').name")
+          echo "servicename=$SERVICE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Download dev artifact (if FROM_ENV is dev)
+        if: ${{ inputs.FROM_ENV == 'dev' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: service-${{ steps.serviceName.outputs.servicename }}-dev-${{ inputs.ARTIFACT_ID }}
+          path: dev-meta
+
+      - name: Checkout deploy-state branch
+        uses: actions/checkout@v4
+        with:
+          ref: deploy-state
+          token: ${{ secrets.WF_GITHUB_TOKEN }}
+
+      - name: Ensure .deploys/service.json exists
+        run: |
+          mkdir -p .deploys
+          [ -f .deploys/service.json ] || echo '{}' > .deploys/service.json
+
+      - name: Load promotion data
+        run: |
+          if [[ "${{ inputs.FROM_ENV }}" == "dev" ]]; then
+            cp dev-meta/service.json from.json
+          else
+            jq --arg env "${{ inputs.FROM_ENV }}" '.[$env]' .deploys/service.json > from.json
+          fi
+
+          cat from.json
+          DIGEST=$(jq -r '.digest' from.json)
+          VERSION_TAG=$(jq -r '.version_tag' from.json)
+          IMAGE_TAG=$(jq -r '.image_tag' from.json)
+
+          if [[ -z "$DIGEST" || "$DIGEST" == "null" ]]; then
+            echo "❌ Missing digest for ${{ inputs.FROM_ENV }}"
+            exit 1
+          fi
+
+          jq --arg env "${{ inputs.TO_ENV }}" \
+             --arg digest "$DIGEST" \
+             --arg version_tag "$VERSION_TAG" \
+             --arg image_tag "$IMAGE_TAG" \
+             '.[$env] = {digest: $digest, version_tag: $version_tag, image_tag: $image_tag}' \
+             .deploys/service.json > tmp.json && mv tmp.json .deploys/service.json
+
+          echo "✅ Promoted ${{
+            steps.serviceName.outputs.servicename
+          }} from ${{ inputs.FROM_ENV }} to ${{ inputs.TO_ENV }}"
+
+      - name: Commit and push promotion
+        run: |
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add .deploys/service.json
+          git commit -m "chore(ci): promote ${{ steps.serviceName.outputs.servicename }} from ${{ inputs.FROM_ENV }} to ${{ inputs.TO_ENV }} [skip ci]" || echo "Nothing to commit"
+          git push origin deploy-state

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -83,9 +83,9 @@ jobs:
           echo "📦 Loaded metadata from ${{ inputs.FROM_ENV }}"
           cat from.json
 
-          DIGEST=$(jq -r '.digest' from.json)
-          VERSION_TAG=$(jq -r '.version_tag' from.json)
-          IMAGE_TAG=$(jq -r '.image_tag' from.json)
+          DIGEST=$(jq -r '.${{ inputs.FROM_ENV }}.digest' from.json)
+          VERSION_TAG=$(jq -r '.${{ inputs.FROM_ENV }}.version_tag' from.json)
+          IMAGE_TAG=$(jq -r '.${{ inputs.FROM_ENV }}.image_tag' from.json)
 
           if [[ -z "$DIGEST" || "$DIGEST" == "null" ]]; then
             echo "❌ Missing digest for ${{ inputs.FROM_ENV }}"


### PR DESCRIPTION
# 🚨 BREAKING CHANGE: Refactor deploy tracking to support "Build Once, Deploy Many"

## ❗ What changed?

This PR introduces a **new deployment strategy** and **refactors deploy metadata handling** to align with the principle of **Build Once, Deploy Many**:

### ✅ Highlights

- 🔁 **Single build artifact** (immutable ECR digest) now reused for multiple environment promotions (e.g. `staging`, `production`)
- 📄 `.deploys/service.json` now tracks **multiple environments** (`staging`, `production`) within a **single JSON structure**
- 🧠 **Idempotent**: safely supports re-runs without overwriting unrelated environment data
- 🌿 Uses Git **worktrees** to isolate deploy-state updates on the `deploy-state` branch
- 🧹 Removed legacy behavior where `service.json` was rewritten per deploy

## 💥 Why is this a breaking change?

- **The format and update behavior of `.deploys/service.json` has changed**
- Any downstream scripts or tooling assuming a single environment or overwrite behavior will break
- The build → deploy workflow has shifted from **build-per-env** to **build-once, promote-by-reference**

> This enforces a clear separation between the **build pipeline** and **environment-specific deployment**, allowing safer and more traceable releases.

## 📌 Migration Guide

| Before | After |
|--------|-------|
| `.deploys/service.json` overwritten on each deploy | Now merged under `{ "staging": {...}, "production": {...} }` |
| Each environment required separate build | Single build is **promoted** via `digest` reference |
| No idempotency guarantees | Re-runs won't overwrite unrelated environment metadata |

### Action items:
- Update any tools reading `.deploys/service.json` to expect the **merged environment format**
- Ensure deployment pipelines for `staging`, `production`, etc. use **the same image digest** (i.e. no rebuilds)
- Validate dashboards or audits that track deployments by tag or digest

## ✅ Checklist

- [x] Breaking change confirmed (affects deploy state persistence and promotion flow)
- [x] PR title includes `BREAKING CHANGE:` for SemVer tooling
- [x] CI tested with `staging` and `production` flows using the same image digest
- [x] Git worktree logic validated for deploy-state branch updates
- [x] Consumers notified to update `.deploys/service.json` parsing logic

---

## 🔍 Related context

- Aligns with GitOps and CI/CD best practices
- Improves auditability and traceability of production deployments
- Supports safer promotions and easier rollbacks by decoupling build from deploy

