### PR TITLE
fix: update ECR workflow runner label

### DIFF
--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, linux-local]
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: [self-hosted, macOS, X64]
+    runs-on: [self-hosted, macOS]
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: [self-hosted, macOS, X64]
+    runs-on: ubuntu-latest-4xlarge
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: ubuntu-latest-4xlarge
+    runs-on: ubuntu-latest-16-cores
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: ubuntu-latest-16-cores
+    runs-on: [self-hosted, macOS, X64]
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-larger
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, X64]
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_build_push_ecr.yml
+++ b/.github/workflows/base_build_push_ecr.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   setup:
     name: push-to-ecr
-    runs-on: ubuntu-larger
+    runs-on: self-hosted
     environment: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
     outputs:
       servicename: ${{ steps.service-name.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -56,7 +56,7 @@ jobs:
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
-    runs-on: [self-hosted, macOS, X64]
+    runs-on: ubuntu-latest-4xlarge
     continue-on-error: false
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -56,7 +56,7 @@ jobs:
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
-    runs-on: self-hosted
+    runs-on: [self-hosted, macOS, X64]
     continue-on-error: false
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -56,7 +56,7 @@ jobs:
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
-    runs-on: ubuntu-latest-4xlarge
+    runs-on: ubuntu-latest-16-cores
     continue-on-error: false
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -56,7 +56,7 @@ jobs:
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
-    runs-on: [self-hosted, macOS]
+    runs-on: [self-hosted, linux-local]
     continue-on-error: false
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -56,7 +56,7 @@ jobs:
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
-    runs-on: ubuntu-latest-16-cores
+    runs-on: [self-hosted, macOS, X64]
     continue-on-error: false
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -56,7 +56,7 @@ jobs:
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     continue-on-error: false
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}

--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -56,7 +56,7 @@ jobs:
     name: preparing
     env:
       FONT_AWESOME_TOKEN: ${{ secrets.WF_FONT_AWESOME_TOKEN }}
-    runs-on: [self-hosted, macOS, X64]
+    runs-on: [self-hosted, macOS]
     continue-on-error: false
     outputs:
       output1: ${{ steps.serviceName.outputs.servicename }}


### PR DESCRIPTION
## Context
This change updates the runner label used by the base ECR workflow so the job executes on the intended GitHub Actions runner.

## What was changed
- Updated `.github/workflows/base_build_push_ecr.yml`
- Changed the `setup` job runner from `ubuntu-latest` to `ubuntu-larger`

## Technical rationale
The workflow needs to target the larger runner label instead of the default Ubuntu image. This aligns the ECR publishing job with the expected execution environment and available runner capacity.

## Impacts and considerations
- Affects only the `CI-ECR-BASE` workflow execution environment
- No application code or runtime behavior is changed
- Workflow execution now depends on availability of the `ubuntu-larger` runner label

## Test plan
- [ ] Validate that the workflow is accepted by GitHub Actions
- [ ] Run the ECR base workflow in a test scenario and confirm the job starts on `ubuntu-larger`
- [ ] Confirm the image load and push steps still complete successfully