### PR TITLE
fix(ci): remove Font Awesome token from workflow_call inputs

### DIFF
--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -16,9 +16,6 @@ on:
       WF_BACKSTAGE_URL:
         type: string
         required: false
-      WF_FONT_AWESOME_TOKEN:
-        type: string
-        required: false
       WF_CREATE_DOTENV_BEFORE_BUILD:
         type: boolean
         default: false


### PR DESCRIPTION
## Summary
Removes `WF_FONT_AWESOME_TOKEN` from the `workflow_call` **inputs** section of `base_node_build.yml`.

## Motivation
Font Awesome authentication is provided via the `secrets` block (`WF_FONT_AWESOME_TOKEN`). Listing it under `inputs` was incorrect and could confuse callers of this reusable workflow.

## Changes
- Delete the duplicate/incorrect `WF_FONT_AWESOME_TOKEN` input definition; secret usage in `env` and `.npmrc` setup is unchanged.

## Testing
- N/A (YAML workflow definition only).