### PR TITLE
feat(gitops): add reusable workflows for bootstrap, ECR and GitOps init (v5.4.0)

### DIFF
--- a/.github/workflows/ci_create_ecr_repo.yml
+++ b/.github/workflows/ci_create_ecr_repo.yml
@@ -1,0 +1,32 @@
+name: CI-CREATE-ECR-REPO
+
+on:
+  workflow_call:
+    inputs:
+      WF_SERVICE_NAME:
+        type: string
+        required: true
+    secrets:
+      WF_AWS_ACCESS_KEY_ID:
+        required: true
+      WF_AWS_SECRET_ACCESS_KEY:
+        required: true
+
+jobs:
+  create-ecr-repo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.WF_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.WF_AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Criar repositório ECR (idempotente)
+        run: |
+          aws ecr create-repository \
+            --repository-name "${{ inputs.WF_SERVICE_NAME }}" \
+            --region us-east-1 \
+            --image-scanning-configuration scanOnPush=true \
+            2>/dev/null || true

--- a/.github/workflows/ci_ensure_main_branch.yml
+++ b/.github/workflows/ci_ensure_main_branch.yml
@@ -1,0 +1,27 @@
+name: CI-ENSURE-MAIN-BRANCH
+
+on:
+  workflow_call:
+    secrets:
+      WF_GITHUB_TOKEN:
+        required: true
+
+jobs:
+  ensure-main-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.WF_GITHUB_TOKEN }}
+
+      - name: Criar branch main se não existir
+        run: |
+          if ! git ls-remote --heads origin main | grep -q 'refs/heads/main'; then
+            git checkout -b main
+            git push origin main
+            echo "Branch main criada a partir de stage."
+          else
+            echo "Branch main já existe."
+          fi

--- a/.github/workflows/ci_init_gitops.yml
+++ b/.github/workflows/ci_init_gitops.yml
@@ -74,11 +74,16 @@ jobs:
               cat > "$SERVICE/$ENV/ingress-values.yaml" << EOF
           ingress:
             public:
+              annotations:
+                cert-manager.io/cluster-issuer: letsencrypt-stg-wildcard
+                kubernetes.io/tls-acme: "true"
+                kubernetes.io/ssl-redirect: "true"
               hosts:
                 - host: $SERVICE.stg.services.quero.io
               tls:
                 - hosts:
                   - $SERVICE.stg.services.quero.io
+                  secretName: $SERVICE.ssl
             internal:
               hosts:
                 - host: $SERVICE.stg.services.local.quero.io
@@ -87,11 +92,16 @@ jobs:
               cat > "$SERVICE/$ENV/ingress-values.yaml" << EOF
           ingress:
             public:
+              annotations:
+                cert-manager.io/cluster-issuer: letsencrypt-prd-wildcard
+                kubernetes.io/tls-acme: "true"
+                kubernetes.io/ssl-redirect: "true"
               hosts:
                 - host: $SERVICE.services.quero.io
               tls:
                 - hosts:
                   - $SERVICE.services.quero.io
+                  secretName: $SERVICE.ssl
             internal:
               hosts:
                 - host: $SERVICE.services.local.quero.io

--- a/.github/workflows/ci_init_gitops.yml
+++ b/.github/workflows/ci_init_gitops.yml
@@ -1,0 +1,127 @@
+name: CI-INIT-GITOPS
+
+on:
+  workflow_call:
+    inputs:
+      WF_SERVICE_NAME:
+        type: string
+        required: true
+      WF_ENV_TYPE_DEPLOY:
+        type: string
+        required: true
+        description: "staging or production"
+    secrets:
+      WF_GITHUB_TOKEN:
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  init-gitops:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout kube-apps-definitions
+        uses: actions/checkout@v4
+        with:
+          repository: QueroDelivery/kube-apps-definitions
+          token: ${{ secrets.WF_GITHUB_TOKEN }}
+
+      - name: Inicializar arquivos GitOps (idempotente)
+        env:
+          SERVICE: ${{ inputs.WF_SERVICE_NAME }}
+          ENV: ${{ inputs.WF_ENV_TYPE_DEPLOY }}
+        run: |
+          set -euo pipefail
+          CHANGED=false
+
+          if [[ "$ENV" == "staging" && ! -f "$SERVICE/base.yaml" ]]; then
+            mkdir -p "$SERVICE"
+            cat > "$SERVICE/base.yaml" << EOF
+          nameOverride: ""
+          fullnameOverride: ""
+          appserverLabel: "node-14"
+          replicaCount: 1
+          image:
+            registry: "650363809795.dkr.ecr.us-east-1.amazonaws.com"
+            repository: "$SERVICE"
+          useExternalConfig: true
+          autoscaling:
+            enabled: true
+            minReplicas: 1
+            maxReplicas: 1
+            targetCPUUtilizationPercentage: 80
+            targetMemoryUtilizationPercentage: 80
+          ingress:
+            public:
+              enabled: true
+            internal:
+              enabled: true
+          resources:
+            limits:
+              cpu: 330m
+              memory: 512Mi
+            requests:
+              cpu: 165m
+              memory: 512Mi
+          EOF
+            CHANGED=true
+          fi
+
+          if [[ ! -f "$SERVICE/$ENV/ingress-values.yaml" ]]; then
+            mkdir -p "$SERVICE/$ENV"
+            if [[ "$ENV" == "staging" ]]; then
+              cat > "$SERVICE/$ENV/ingress-values.yaml" << EOF
+          ingress:
+            public:
+              hosts:
+                - host: $SERVICE.stg.services.quero.io
+              tls:
+                - hosts:
+                  - $SERVICE.stg.services.quero.io
+            internal:
+              hosts:
+                - host: $SERVICE.stg.services.local.quero.io
+          EOF
+            else
+              cat > "$SERVICE/$ENV/ingress-values.yaml" << EOF
+          ingress:
+            public:
+              hosts:
+                - host: $SERVICE.services.quero.io
+              tls:
+                - hosts:
+                  - $SERVICE.services.quero.io
+            internal:
+              hosts:
+                - host: $SERVICE.services.local.quero.io
+          EOF
+            fi
+            CHANGED=true
+          fi
+
+          if [[ ! -f "$SERVICE/$ENV/override-values.yaml" ]]; then
+            mkdir -p "$SERVICE/$ENV"
+            cat > "$SERVICE/$ENV/override-values.yaml" << 'EOF'
+          resources:
+            limits:
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          autoscaling:
+            minReplicas: 1
+            maxReplicas: 1
+          EOF
+            CHANGED=true
+          fi
+
+          if [[ "$CHANGED" == "true" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add "$SERVICE/"
+            git commit -m "chore($SERVICE): inicializar definições GitOps de $ENV"
+            git push origin HEAD || (git pull --rebase origin main && git push origin HEAD)
+          else
+            echo "Arquivos de $ENV já existem — nenhuma inicialização necessária."
+          fi


### PR DESCRIPTION
## Summary

- Adds `ci_ensure_main_branch.yml`: idempotently creates the `main` branch from `stage` if it doesn't exist (runs once on first service deploy)
- Adds `ci_create_ecr_repo.yml`: idempotently creates an ECR repository with `scanOnPush=true`
- Adds `ci_init_gitops.yml`: initialises `kube-apps-definitions` files for a new service — `base.yaml` + `{env}/ingress-values.yaml` + `{env}/override-values.yaml` — for both staging and production environments

These workflows replace heavy inline bash jobs that lived directly in template `push_stage.yml` and `push_main.yml`, making the template purely declarative.

## Motivation

Template had ~150 lines of inline bash spread across 3 jobs. Every service repo that uses the template carried this boilerplate, making maintenance and evolution painful. Moving the logic here means a single fix propagates to all services on the next version bump.

## Test plan

- [ ] Merge triggers `semantic-release` → `v5.4.0` tag created
- [ ] Update template skeleton to reference `@v5.4.0` for all workflows
- [ ] First deploy of a new service from template: verify `main` branch is created, ECR repo exists, kube-apps-definitions files are initialised

🤖 Generated with [Claude Code](https://claude.com/claude-code)