### PR TITLE
fix(ci): reduzir retenção de artefatos de build para 1 dia

### DIFF
--- a/.github/workflows/base_node_build.yml
+++ b/.github/workflows/base_node_build.yml
@@ -158,3 +158,4 @@ jobs:
         with:
           name: built-image
           path: image.tar.gz
+          retention-days: 1

--- a/.github/workflows/base_python_build.yml
+++ b/.github/workflows/base_python_build.yml
@@ -90,3 +90,4 @@ jobs:
         with:
           name: built-image
           path: image.tar.gz
+          retention-days: 1


### PR DESCRIPTION
## O problema

O artefato `image.tar.gz` gerado pelos workflows `base_node_build.yml` e `base_python_build.yml` é uma embalagem temporária — existe apenas para passar a imagem Docker entre dois jobs do mesmo pipeline:

```
base_node_build.yml  →  faz upload do image.tar.gz
        ↓  (~10-30 min depois)
base_build_push_ecr.yml  →  baixa, envia pro ECR, pronto
```

Após o job de ECR concluir, o artefato não tem mais nenhuma utilidade. Mesmo assim, a retenção padrão do GitHub Actions é de **90 dias**.

## Impacto observado

Em maio/2026, o storage acumulado de artefatos chegou a **519k GB-hours**, representando **$173,92** do total de **$300,04** que esgotou o budget de Actions da org QueroDelivery.

## A mudança

```yaml
- uses: actions/upload-artifact@v4
  with:
    name: built-image
    path: image.tar.gz
    retention-days: 1  # era 90 (padrão)
```

1 dia é mais do que suficiente: o pipeline completo termina em no máximo 30-60 minutos. A única razão para guardar por mais tempo seria re-executar manualmente só o job de ECR sem rebuildar — cenário raro e que não justifica 90 dias.

## Arquivos alterados

- `.github/workflows/base_node_build.yml`
- `.github/workflows/base_python_build.yml`

## Efeito

Aplicado nos dois base workflows, a correção se propaga automaticamente para todos os ~49 serviços que os utilizam — sem nenhuma mudança nos repositórios individuais.

> **Nota:** artefatos já existentes expirarão pelo TTL anterior. A redução de custo aparece progressivamente nas próximas semanas.