### PR TITLE
refactor(ci): define GH_TOKEN_CI at workflow env level

### DIFF
--- a/.github/workflows/ci_s3_deploy_multi_environment.yml
+++ b/.github/workflows/ci_s3_deploy_multi_environment.yml
@@ -40,6 +40,7 @@ env:
   IS_PREVIEW: ${{ inputs.is_preview }}
   VITE_BROWSER_ROUTER_BASENAME: ${{ inputs.is_preview && format('/preview-pr-{0}', github.event.pull_request.number) || '/' }}
   REACT_APP_BROWSER_ROUTER_BASENAME: ${{ inputs.is_preview && format('/preview-pr-{0}', github.event.pull_request.number) || '/' }}
+  GH_TOKEN_CI: ${{ secrets.WF_GITHUB_TOKEN }}
 
 jobs:
   build_and_upload_to_s3:


### PR DESCRIPTION
## Summary
Adds `GH_TOKEN_CI` to the top-level `env` block in `ci_s3_deploy_multi_environment.yml`, mapped from `secrets.WF_GITHUB_TOKEN`.

## Motivation
Both deploy jobs need the same GitHub token for CI scripts. Defining it once at workflow scope avoids duplicating the same `env` block on each job.

## Changes
- Set `GH_TOKEN_CI` alongside preview-related env vars (`APP_PREFIX`, `IS_PREVIEW`, router basenames).

## Testing
- Call the reusable workflow from a consumer repo and confirm steps that rely on `GH_TOKEN_CI` still authenticate (e.g. install/build/release).