### PR TITLE
feat(docs): release note for GH_TOKEN_CI workflow env (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ flowchart TD
     F --> G[Retag image in ECR]
     G --> H[Push deploy-state]
 ```
-The `ci_local.yml` workflow is used only for running semantic-release locally.
+The `ci_local.yml` workflow is used only for running semantic-release locally


### PR DESCRIPTION
## Summary
Removes the trailing period on the `ci_local.yml` note at the end of `README.md`.

## Related changes
- #92 — `GH_TOKEN_CI` at workflow `env` level in `ci_s3_deploy_multi_environment.yml` (merged as `refactor`, no semver bump)
- This `feat` commit triggers semantic-release so consumers get a new tagged version including that workflow change.

## Changes
- One line in `README.md` (punctuation only)

## Testing
- Merge to `main` and confirm semantic-release publishes a new version.