### PR TITLE
fix(ci_init_gitops): add limits.cpu to staging override-values.yaml template

### DIFF
--- a/.github/workflows/ci_init_gitops.yml
+++ b/.github/workflows/ci_init_gitops.yml
@@ -111,6 +111,7 @@ jobs:
             cat > "$SERVICE/$ENV/override-values.yaml" << 'EOF'
           resources:
             limits:
+              cpu: 150m
               memory: 256Mi
             requests:
               cpu: 150m


### PR DESCRIPTION
## Problema

Quando `ci_init_gitops.yml` cria `staging/override-values.yaml` para um serviço novo, o template gerado omite `limits.cpu`:

```yaml
resources:
  limits:
    memory: 256Mi      # ← sem limits.cpu!
  requests:
    cpu: 150m
    memory: 256Mi
```

O Kubernetes herda `limits.cpu` do `base.yaml` do serviço (pode ser 80m ou 85m). Como `requests.cpu: 150m > limits.cpu: 80m`, o K8s rejeita e o ArgoCD fica em OutOfSync.

## Fix

Adicionar `limits.cpu: 150m` explicitamente no template:

```yaml
resources:
  limits:
    cpu: 150m          # ← adicionado
    memory: 256Mi
  requests:
    cpu: 150m
    memory: 256Mi
```

## Impacto observado

8 serviços ficaram `OutOfSync` no ArgoCD staging após migração GitOps:
- qd-auth, qd-bank-log-service, qd-bank-service, qd-conventional-receipt-service
- qd-integration-webhooks, qd-merlot-service, qd-payment-service, qd-schedule

Workaround aplicado em `kube-apps-definitions` adicionando `limits.cpu: 150m` manualmente nos overrides afetados.