### PR TITLE
[CD-7693] - feat(ci): add optional auto PR creation from stage to main on S3 deploy

### DIFF
--- a/.github/workflows/ci_s3_deploy_multi_environment.yml
+++ b/.github/workflows/ci_s3_deploy_multi_environment.yml
@@ -21,6 +21,10 @@ on:
         required: false
         type: boolean
         default: false
+      create_pr_in_main:
+        required: false
+        type: boolean
+        default: false
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -152,6 +156,37 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_REGION: ${{ secrets.AWS_REGION }}
           S3_BUCKET_NAME: ${{ format('s3://{0}/{1}', secrets.S3_BUCKET_NAME, env.APP_PREFIX) }}
+
+      - name: Check if there are commits between stage and main
+        id: check_commits
+        if: ${{ inputs.create_pr_in_main && inputs.environment_type == 'stage' && !inputs.is_preview }}
+        run: |
+          git fetch origin main stage
+          if [ "$(git rev-list --count origin/main..origin/stage)" -eq 0 ]; then
+            echo "commits_ahead=false" >> $GITHUB_OUTPUT
+          else
+            echo "commits_ahead=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check if PR already exists
+        id: check_pr
+        if: ${{ inputs.create_pr_in_main && inputs.environment_type == 'stage' && !inputs.is_preview && steps.check_commits.outputs.commits_ahead == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
+        run: |
+          pr_exists=$(gh pr list --base main --head stage --state open --json number --jq '. | length')
+          echo "pr_exists=$pr_exists" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request for prod
+        if: ${{ inputs.create_pr_in_main && inputs.environment_type == 'stage' && !inputs.is_preview && steps.check_commits.outputs.commits_ahead == 'true' && steps.check_pr.outputs.pr_exists == '0' }}
+        env:
+          GH_TOKEN: ${{ secrets.WF_GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --base main \
+            --head stage \
+            --title "Deploy in prod" \
+            --body "Pull request body"
 
   publish_application_and_invalidate_cache:
     needs: build_and_upload_to_s3


### PR DESCRIPTION
## Summary

- Adds a new `create_pr_in_main` workflow input to the S3 multi-environment deploy workflow
- When enabled on stage deploys (non-preview), automatically checks if `stage` has commits ahead of `main`
- Creates a PR from `stage` to `main` with title "Deploy in prod" if no open PR already exists

## Test plan

- [ ] Trigger S3 deploy workflow with `create_pr_in_main: true` on a stage environment
- [ ] Verify PR is created when stage has commits ahead of main and no open PR exists
- [ ] Verify PR is skipped when stage and main are in sync
- [ ] Verify PR is skipped when an open PR from stage to main already exists
- [ ] Verify no PR is created for preview deploys or non-stage environments