### PR TITLE
[CD-7821] - fix(ci): pass WF_GITHUB_TOKEN to checkout for git fetch and PR creation

### DIFF
--- a/.github/workflows/ci_s3_deploy_multi_environment.yml
+++ b/.github/workflows/ci_s3_deploy_multi_environment.yml
@@ -68,6 +68,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.WF_GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

- Passes `WF_GITHUB_TOKEN` to the `actions/checkout` step in the S3 multi-environment deploy workflow

## Motivation

The semantic release step (`yarn release`) needs to push version commits to the protected `main` branch. The default `GITHUB_TOKEN` used by `actions/checkout` does not have bypass permission on the branch protection ruleset, which prevents semantic release from completing successfully.

Passing `WF_GITHUB_TOKEN` to checkout authenticates git operations with a token configured to bypass branch protection, enabling semantic release commits during deploy.

## Changes

- Add `with.token: ${{ secrets.WF_GITHUB_TOKEN }}` to the Checkout step in `build_and_upload_to_s3`

## Test plan

- [ ] Trigger deploy with `has_semantic_release: true` on a consumer repo targeting `main`
- [ ] Confirm semantic release completes and pushes version commits to the protected `main` branch
- [ ] Verify the new version tag is created and published