### PR TITLE
[CD-7808] - fix(ci): simplify CloudFront cache invalidation to single /* path

### DIFF
--- a/.github/workflows/ci_s3_deploy_multi_environment.yml
+++ b/.github/workflows/ci_s3_deploy_multi_environment.yml
@@ -196,55 +196,7 @@ jobs:
       name: ${{ inputs.environment_type }}
 
     steps:
-      - name: Verify if has some invalidation with "/*" path
-        id: check_full_invalidation
-        run: |
-          DIST_ID="${CLOUDFRONT_DISTRIBUTION_ID}"
-
-          echo "🔍 Searching invalidations"
-          IDS=$(aws cloudfront list-invalidations \
-            --distribution-id "$DIST_ID" \
-            --query "InvalidationList.Items[].Id" \
-            --output text)
-
-          FOUND="no"
-
-          for ID in $IDS; do
-            MATCH=$(aws cloudfront get-invalidation \
-              --distribution-id "$DIST_ID" \
-              --id "$ID" \
-              --query "Invalidation.InvalidationBatch.Paths.Items" \
-              --output text | grep -Fx "/*" || true)
-
-            if [[ "$MATCH" == "/*" ]]; then
-              FOUND="yes"
-              break
-            fi
-          done
-
-          echo "✅ Invalidation founded? $FOUND"
-          echo "has_full_invalidation=$FOUND" >> "$GITHUB_OUTPUT"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-
-      - name: Invalidate CloudFront cache (index.html ONLY)
-        if: ${{ steps.check_full_invalidation.outputs.has_full_invalidation == 'yes' }}
-        run: |
-          PREFIX="/${APP_PREFIX#"/"}"
-          aws cloudfront create-invalidation \
-            --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "$PREFIX/index.html"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
-          CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          APP_PREFIX: ${{ env.APP_PREFIX }}
-
-      - name: Invalidate CloudFront cache (ALL)
-        if: ${{ steps.check_full_invalidation.outputs.has_full_invalidation == 'no' }}
+      - name: Invalidate CloudFront cache
         run: |
           aws cloudfront create-invalidation \
             --distribution-id $CLOUDFRONT_DISTRIBUTION_ID --paths "/*"


### PR DESCRIPTION
## Summary

- Replace conditional CloudFront cache invalidation logic with a single step that always invalidates `/*`

## Motivation

The previous workflow checked for active full-path invalidations and conditionally invalidated only `index.html` when one was already in progress. This added complexity and could leave stale assets cached when a partial invalidation was chosen instead of a full cache bust.

## Changes

- Remove the step that listed and inspected active CloudFront invalidations
- Remove conditional `index.html`-only and full `/*` invalidation branches
- Add a single `Invalidate CloudFront cache` step that always runs `create-invalidation` with path `/*`

## Test plan

- [ ] Trigger S3 deploy workflow on a consumer repo (stage and prod)
- [ ] Confirm the `publish_application_and_invalidate_cache` job completes successfully
- [ ] Verify CloudFront invalidation is created with path `/*` in AWS console
- [ ] Confirm the deployed application serves updated assets after invalidation completes